### PR TITLE
storiesonline.net login requires https

### DIFF
--- a/fanficfare/adapters/adapter_storiesonlinenet.py
+++ b/fanficfare/adapters/adapter_storiesonlinenet.py
@@ -92,7 +92,7 @@ class StoriesOnlineNetAdapter(BaseSiteAdapter):
         params['page'] = 'http://'+self.getSiteDomain()+'/'
         params['submit'] = 'Login'
 
-        loginUrl = 'http://' + self.getSiteDomain() + '/login.php'
+        loginUrl = 'https://' + self.getSiteDomain() + '/login.php'
         logger.debug("Will now login to URL (%s) as (%s)" % (loginUrl,
                                                               params['theusername']))
 


### PR DESCRIPTION
The old HTTP login page now returns a 404 error. Use HTTPS instead.