### PR TITLE
Fix "got more than 100 headers"-issue

### DIFF
--- a/fanficfare/adapters/adapter_royalroadl.py
+++ b/fanficfare/adapters/adapter_royalroadl.py
@@ -15,21 +15,26 @@
 # limitations under the License.
 #
 
-import time
+from datetime import datetime
+import httplib
 import logging
-logger = logging.getLogger(__name__)
 import re
 import urllib2
-import cookielib as cl
-from datetime import datetime
 
-from ..htmlcleanup import stripHTML
 from .. import exceptions as exceptions
+from ..htmlcleanup import stripHTML
+from base_adapter import BaseSiteAdapter
 
-from base_adapter import BaseSiteAdapter,  makeDate
+logger = logging.getLogger(__name__)
+# Fix "http.client.HTTPException: got more than 100 headers" issue. RoyalRoadL's webserver seems to be misconfigured and
+# sends more than 100 headers for some stories (probably Set-Cookie). This simply increases the maximum header limit to
+# 1000 -- changing this state globally isn't an issue, since it should be backwards-compatible with all other adapters.
+httplib._MAXHEADERS = 1000
+
 
 def getClass():
     return RoyalRoadAdapter
+
 
 # Class name has to be unique.  Our convention is camel case the
 # sitename with Adapter at the end.  www is skipped.


### PR DESCRIPTION
For stories that reach a certain size the webserver seems to do something strange and sends out more than 100 headers, which breaks an internal assertion in httplib apparently. This simply increases that limit to 1000 globally when the adapter module is imported initially.

Example URL: http://royalroadl.com/fiction/5927