### PR TITLE
Webnovel.com broken get category

### DIFF
--- a/fanficfare/adapters/adapter_webnovelcom.py
+++ b/fanficfare/adapters/adapter_webnovelcom.py
@@ -154,9 +154,9 @@ class WWWWebNovelComAdapter(BaseSiteAdapter):
                 self.story.setMetadata('translator', parat.replace('Translator:', '').strip())
             elif parat[:7] == 'Editor:':
                 self.story.setMetadata('editor', parat.replace('Editor:', '').strip())
-
-        category = stripHTML(paras[0].strong).strip()
-        self.story.setMetadata('category', category)
+            elif '_tags' in para.get('class', []):
+                category = stripHTML(para.strong).strip()
+                self.story.setMetadata('category', category)
 
         ## get _csrfToken cookie for chapter list fetch
         csrfToken = None


### PR DESCRIPTION
After site update, structure around category changed from:

```
<div>
  <h2>Title <small>ABBR</small></h2>
  <p class="_tags"><strong class="ttc">Category</strong>...</p>
  ...
</div>
```

to:

```
<div>
  <h2>Title <small>ABBR</small></h2>
  <p class="_boost">Tag1 · Tag2 · ...</p>
  <p class="_tags"><strong class="ttc">Category</strong>...</p>
  ...
</div>
```

so getting a story failed.