### PR TITLE
www.novelall.com chapters and characters fixes

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -122,6 +122,11 @@ include_tocpage: true
 ## value 'auto' will call chardet and use the encoding it reports if
 ## it has +90% confidence.  'auto' is not reliable.
 #website_encodings: utf8, Windows-1252, iso-8859-1
+## For sites (or individual stories) with problematic characters you
+## can include ':ignore' after the encoding.  This will discard
+## unrecognized characters, but likely also prevent the rest of the
+## encoding list from ever being used.
+#website_encodings: utf8:ignore, Windows-1252, iso-8859-1
 
 ## When using 'auto' in website_encodings, you can tweak the
 ## confidence required to use the chardet detected.
@@ -2709,6 +2714,8 @@ extracategories:Naruto
 extracategories:NCIS
 
 [www.novelall.com]
+website_encodings: utf8:ignore, Windows-1252, iso-8859-1
+
 ## Clear FanFiction from defaults, site is original fiction.
 extratags:
 extra_valid_entries:stars,votes,releaseFrequency,views,released,follows,altTitles,translator,sitetags

--- a/fanficfare/adapters/adapter_wwwnovelallcom.py
+++ b/fanficfare/adapters/adapter_wwwnovelallcom.py
@@ -214,6 +214,10 @@ class WWWNovelAllComAdapter(BaseSiteAdapter):
     def getChapterText(self, url):
         data = self._fetchUrl(url)
 
+        # remove unnecessary <br> created to add space between advert
+        data = re.sub(r"<br><script", "<script", data)
+        data = re.sub(r"script><br>", "script>", data)
+
         if self.getConfig('fix_excess_space', False):
             data = fix_excess_space(data)
 

--- a/fanficfare/adapters/adapter_wwwnovelallcom.py
+++ b/fanficfare/adapters/adapter_wwwnovelallcom.py
@@ -89,6 +89,13 @@ class WWWNovelAllComAdapter(BaseSiteAdapter):
         # https://www.novelall.com/novel/Castle-of-Black-Iron.html
         return r"https://www\.novelall\.com/novel/(?P<id>[^\.]+)\.html"
 
+    def use_pagecache(self):
+        '''
+        adapters that will work with the page cache need to implement
+        this and change it to True.
+        '''
+        return True
+
     def extractChapterUrlsAndMetadata(self):
         if self.is_adult or self.getConfig("is_adult"):
             addurl = "?waring=1"
@@ -206,9 +213,6 @@ class WWWNovelAllComAdapter(BaseSiteAdapter):
 
     def getChapterText(self, url):
         data = self._fetchUrl(url)
-
-        # Sometimes we get invalid characters
-        data = data.decode('utf-8','ignore').encode('utf-8')
 
         if self.getConfig('fix_excess_space', False):
             data = fix_excess_space(data)

--- a/fanficfare/adapters/adapter_wwwnovelallcom.py
+++ b/fanficfare/adapters/adapter_wwwnovelallcom.py
@@ -70,8 +70,8 @@ class WWWNovelAllComAdapter(BaseSiteAdapter):
 
             # normalized story URL.
             self._setURL("https://"+self.getSiteDomain()
-                         +"/novel/"+self.story.getMetadata('storyId')
-                         +".html")
+                         + "/novel/"+self.story.getMetadata('storyId')
+                         + ".html")
         else:
             raise exceptions.InvalidStoryURL(url,
                                              self.getSiteDomain(),
@@ -155,7 +155,7 @@ class WWWNovelAllComAdapter(BaseSiteAdapter):
             self.story.setMetadata('released', released.find_next_sibling('a').string.strip())
 
         ## getting follows
-        follows = soup.find('num', {"id":"follow_num"})
+        follows = soup.find('num', {"id": "follow_num"})
         if follows:
             self.story.setMetadata('follows', follows.string)
 
@@ -202,7 +202,7 @@ class WWWNovelAllComAdapter(BaseSiteAdapter):
                 cdates.append(makeDate(dt, '%b %d, %Y'))
             # <a href="https://www.novelall.com/chapter/Stellar-Transformation-Volume-18-Chapter-45-part2/616971/" title="Stellar Transformation Volume 18 Chapter 45 part2">
             a = li.find('a')
-            ctitle = a['title'].replace(title, '').strip()
+            ctitle = re.sub(r"^%s(.+)$" % re.escape(title), r"\1", a['title'], 0, re.UNICODE | re.IGNORECASE).strip()
             self.chapterUrls.append((ctitle, a['href']))
 
         cdates.sort()

--- a/fanficfare/cli.py
+++ b/fanficfare/cli.py
@@ -437,7 +437,7 @@ def do_download(arg,
                 call(string.Template(adapter.getConfig('pre_process_cmd')).substitute(metadata), shell=True)
 
             output_filename = write_story(configuration, adapter, options.format, options.metaonly)
-            
+
             if options.metaonly:
                 metadata['output_filename'] = output_filename
                 if options.jsonmeta:

--- a/fanficfare/configurable.py
+++ b/fanficfare/configurable.py
@@ -940,6 +940,9 @@ class Configuration(ConfigParser.SafeConfigParser):
         for code in decode:
             try:
                 #print code
+                errors=None
+                if ':' in code:
+                    (code,errors)=code.split(':')
                 if code == "auto":
                     if not chardet:
                         logger.info("chardet not available, skipping 'auto' encoding")
@@ -952,7 +955,10 @@ class Configuration(ConfigParser.SafeConfigParser):
                     else:
                         logger.debug("chardet confidence too low:%s(%s)"%(detected['encoding'],detected['confidence']))
                         continue
-                return data.decode(code)
+                if errors == 'ignore': # only allow ignore.
+                    return data.decode(code,errors='ignore')
+                else:
+                    return data.decode(code)
             except:
                 logger.debug("code failed:"+code)
                 pass

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -122,6 +122,11 @@ include_tocpage: true
 ## value 'auto' will call chardet and use the encoding it reports if
 ## it has +90% confidence.  'auto' is not reliable.
 #website_encodings: utf8, Windows-1252, iso-8859-1
+## For sites (or individual stories) with problematic characters you
+## can include ':ignore' after the encoding.  This will discard
+## unrecognized characters, but likely also prevent the rest of the
+## encoding list from ever being used.
+#website_encodings: utf8:ignore, Windows-1252, iso-8859-1
 
 ## When using 'auto' in website_encodings, you can tweak the
 ## confidence required to use the chardet detected.
@@ -2737,6 +2742,8 @@ extracategories:Naruto
 extracategories:NCIS
 
 [www.novelall.com]
+website_encodings: utf8:ignore, Windows-1252, iso-8859-1
+
 ## Clear FanFiction from defaults, site is original fiction.
 extratags:
 extra_valid_entries:stars,votes,releaseFrequency,views,released,follows,altTitles,translator,sitetags


### PR DESCRIPTION
chapter bug example:
https://www.novelall.com/novel/Legend-of-the-Cultivation-God.html
title "Legend Of The Cultivation" and chaptername "
Legend of the Cultivation God Chapter 158", so I added re.IGNORECASE


character bug example:
https://www.novelall.com/novel/Log-Horizon.html
https://www.novelall.com/chapter/Legend-of-the-Cultivation-God-Chapter-153/155357/
https://www.novelall.com/chapter/Only-I-Shall-Be-Immortal-Chapter-7-2/177081/
By default _fetchUrl return unicode string with already invalid characters, so we use _fetchUrlRawOpened, which return byte string. As example \xc3\xa2\xc2\x80\xc2\x99 instead of \xe2\x80\x99.

And "br around advert" commit speaks for itself.