### PR TITLE
adapter_webnovelcom: update title selection

### DIFF
--- a/fanficfare/adapters/adapter_webnovelcom.py
+++ b/fanficfare/adapters/adapter_webnovelcom.py
@@ -121,7 +121,7 @@ class WWWWebNovelComAdapter(BaseSiteAdapter):
         bookdetails = soup.find('div', {'class': 'g_col_8'})
 
         # Title
-        title = bookdetails.find('h2', {'class': 'pt8'})
+        title = bookdetails.find('h2')
         # done as a loop incase there isn't one, or more than one.
         for tag in title.find_all('small'):
             tag.extract()


### PR DESCRIPTION
The title style has been changed on 30th July 2018 between 03:00 UTC and
10:00 UTC. Before the tag was was: `<h2 class="pt8 pb8 oh f_serif">`,
now it is `<h2 class="pt4 pb4 oh mb4">`.

To fix it we just need to select for `h2` since there is only one `h2`
in the book details section and the `pt8` is just a styling class
(for `padding-top: 8px`) that may change when style is changed.