### PR TITLE
Fix adapter_wuxiaworldco description decomposition

### DIFF
--- a/fanficfare/adapters/adapter_wuxiaworldco.py
+++ b/fanficfare/adapters/adapter_wuxiaworldco.py
@@ -97,7 +97,8 @@ class WuxiaWorldCoSiteAdapter(BaseSiteAdapter):
 
         intro = soup.select_one('#intro')
         # Strip <strong>Description</strong>
-        intro.strong.decompose()
+        if intro.strong:
+            intro.strong.decompose()
         self.setDescription(self.url, intro)
 
         for a in soup.select('#list a'):

--- a/fanficfare/configurable.py
+++ b/fanficfare/configurable.py
@@ -1172,7 +1172,6 @@ class Configuration(configparser.SafeConfigParser):
                     break # break out on 404
             except Exception as e:
                 excpt=e
-                raise
                 logger.debug("Caught an exception reading URL: %s sleeptime(%s) Exception %s."%(unicode(safe_url(url)),sleeptime,unicode(e)))
 
         logger.debug("Giving up on %s" %safe_url(url))


### PR DESCRIPTION
wuxiaworld.co not always has strong tag in description 

Example:
https://www.wuxiaworld.co/Tales-of-Demons-and-Gods/

Also removed `raise` when download chapter failed, because didn't work sleeptimes algorithm.
