### PR TITLE
Fix author parsing at webnovelcom

### DIFF
--- a/fanficfare/adapters/adapter_webnovelcom.py
+++ b/fanficfare/adapters/adapter_webnovelcom.py
@@ -141,7 +141,7 @@ class WWWWebNovelComAdapter(BaseSiteAdapter):
 
         def parse_meta(mt,label,setmd):
             if label in mt:
-                data = mt.split(label,1)[1].split(u'|', 1)[0].strip()
+                data = mt.split(label,1)[1].split('Translator:', 1)[0].split('Editor:', 1)[0].strip()
                 if data:
                     # print("setting %s to %s"%(setmd, data))
                     self.story.setMetadata(setmd, data)


### PR DESCRIPTION
There is not more separator `|` between Author and Translator.

example mt - `Author:Pear Lands In The Autumn SpringTranslator:CKtalonEditor:CKtalon`
