### PR TITLE
calibre plugin: on the road to python3

### DIFF
--- a/calibre-plugin/basicinihighlighter.py
+++ b/calibre-plugin/basicinihighlighter.py
@@ -14,6 +14,8 @@ try:
 except ImportError as e:
     from PyQt4.Qt import (Qt, QSyntaxHighlighter, QTextCharFormat, QBrush)
 
+from .fanficfare.six import string_types
+
 class BasicIniHighlighter(QSyntaxHighlighter):
     '''
     QSyntaxHighlighter class for use with QTextEdit for highlighting
@@ -53,7 +55,7 @@ class BasicIniHighlighter(QSyntaxHighlighter):
 
 class HighlightingRule():
     def __init__( self, pattern, color, style ):
-        if isinstance(pattern,basestring):
+        if isinstance(pattern, string_types):
             self.pattern = re.compile(pattern)
         else:
             self.pattern=pattern

--- a/calibre-plugin/basicinihighlighter.py
+++ b/calibre-plugin/basicinihighlighter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (unicode_literals, division,
+from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
 __license__   = 'GPL v3'
@@ -23,11 +23,11 @@ class BasicIniHighlighter(QSyntaxHighlighter):
     format, so I'm leaving this in the project even though I'm not
     using.
     '''
-    
+
     def __init__( self, parent, theme ):
         QSyntaxHighlighter.__init__( self, parent )
         self.parent = parent
-        
+
         self.highlightingRules = []
 
         # keyword
@@ -61,4 +61,3 @@ class HighlightingRule():
         brush = QBrush(color, style)
         charfmt.setForeground(brush)
         self.highlight = charfmt
-    

--- a/calibre-plugin/common_utils.py
+++ b/calibre-plugin/common_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import (unicode_literals, division, absolute_import,
                         print_function)
+import six
 
 __license__   = 'GPL v3'
 __copyright__ = '2011, Grant Drake <grant.drake@gmail.com>, 2018, Jim Miller'
@@ -367,7 +368,7 @@ class KeyValueComboBox(QComboBox):
     def populate_combo(self, selected_key):
         self.clear()
         selected_idx = idx = -1
-        for key, value in self.values.iteritems():
+        for key, value in six.iteritems(self.values):
             idx = idx + 1
             self.addItem(value)
             if key == selected_key:
@@ -375,7 +376,7 @@ class KeyValueComboBox(QComboBox):
         self.setCurrentIndex(selected_idx)
 
     def selected_key(self):
-        for key, value in self.values.iteritems():
+        for key, value in six.iteritems(self.values):
             if value == unicode(self.currentText()).strip():
                 return key
 
@@ -533,7 +534,7 @@ class PrefsViewerDialog(SizePersistedDialog):
     def _populate_settings(self):
         self.keys_list.clear()
         ns_prefix = self._get_ns_prefix()
-        keys = sorted([k[len(ns_prefix):] for k in self.db.prefs.iterkeys()
+        keys = sorted([k[len(ns_prefix):] for k in six.iterkeys(self.db.prefs)
                        if k.startswith(ns_prefix)])
         for key in keys:
             self.keys_list.addItem(key)
@@ -596,7 +597,7 @@ class PrefsViewerDialog(SizePersistedDialog):
         if not confirm(message, self.namespace+'_clear_settings', self):
             return
         ns_prefix = self._get_ns_prefix()
-        keys = [k for k in self.db.prefs.iterkeys() if k.startswith(ns_prefix)]
+        keys = [k for k in six.iterkeys(self.db.prefs) if k.startswith(ns_prefix)]
         for k in keys:
             del self.db.prefs[k]
         self._populate_settings()

--- a/calibre-plugin/common_utils.py
+++ b/calibre-plugin/common_utils.py
@@ -28,6 +28,7 @@ from calibre.gui2.actions import menu_action_unique_name
 from calibre.gui2.keyboard import ShortcutConfig
 from calibre.utils.config import config_dir
 from calibre.utils.date import now, format_date, qt_to_dt, UNDEFINED_DATE
+from .fanficfare.six import text_type as unicode
 
 # Global definition of our plugin name. Used for common functions that require this.
 plugin_name = None
@@ -615,4 +616,3 @@ class PrefsViewerDialog(SizePersistedDialog):
         self.close()
         if d.do_restart:
             self.gui.quit(restart=True)
-

--- a/calibre-plugin/config.py
+++ b/calibre-plugin/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import (unicode_literals, division, absolute_import,
                         print_function)
+import six
 
 __license__   = 'GPL v3'
 __copyright__ = '2019, Jim Miller'
@@ -190,7 +191,7 @@ class RejectURLList:
                 self._save_list(listcache)
 
     def add_text(self,rejecttext,addreasontext):
-        self.add(self._read_list_from_text(rejecttext,addreasontext).values())
+        self.add(list(self._read_list_from_text(rejecttext,addreasontext).values()))
 
     def add(self,rejectlist,clear=False):
         with self.sync_lock:
@@ -203,7 +204,7 @@ class RejectURLList:
             self._save_list(listcache)
 
     def get_list(self):
-        return self._get_listcache().values()
+        return list(self._get_listcache().values())
 
     def get_reject_reasons(self):
         return self.prefs['rejectreasons'].splitlines()
@@ -329,7 +330,7 @@ class ConfigWidget(QWidget):
             prefs['plugin_gen_cover'] = self.calibrecover_tab.plugin_gen_cover.isChecked()
             prefs['gcnewonly'] = self.calibrecover_tab.gcnewonly.isChecked()
             gc_site_settings = {}
-            for (site,combo) in self.calibrecover_tab.gc_dropdowns.iteritems():
+            for (site,combo) in six.iteritems(self.calibrecover_tab.gc_dropdowns):
                 val = unicode(convert_qvariant(combo.itemData(combo.currentIndex())))
                 if val != 'none':
                     gc_site_settings[site] = val
@@ -357,7 +358,7 @@ class ConfigWidget(QWidget):
 
             # Standard Columns tab
             colsnewonly = {}
-            for (col,checkbox) in self.std_columns_tab.stdcol_newonlycheck.iteritems():
+            for (col,checkbox) in six.iteritems(self.std_columns_tab.stdcol_newonlycheck):
                 colsnewonly[col] = checkbox.isChecked()
             prefs['std_cols_newonly'] = colsnewonly
 
@@ -383,7 +384,7 @@ class ConfigWidget(QWidget):
 
             # cust cols tab
             colsmap = {}
-            for (col,combo) in self.cust_columns_tab.custcol_dropdowns.iteritems():
+            for (col,combo) in six.iteritems(self.cust_columns_tab.custcol_dropdowns):
                 val = unicode(convert_qvariant(combo.itemData(combo.currentIndex())))
                 if val != 'none':
                     colsmap[col] = val
@@ -391,7 +392,7 @@ class ConfigWidget(QWidget):
             prefs['custom_cols'] = colsmap
 
             colsnewonly = {}
-            for (col,checkbox) in self.cust_columns_tab.custcol_newonlycheck.iteritems():
+            for (col,checkbox) in six.iteritems(self.cust_columns_tab.custcol_newonlycheck):
                 colsnewonly[col] = checkbox.isChecked()
             prefs['custom_cols_newonly'] = colsnewonly
 
@@ -818,7 +819,7 @@ class PersonalIniTab(QWidget):
 
     def show_defaults(self):
         IniTextDialog(self,
-                       get_resources('plugin-defaults.ini'),
+                       get_resources('plugin-defaults.ini').decode('utf-8'),
                        icon=self.windowIcon(),
                        title=_('Plugin Defaults'),
                        label=_("Plugin Defaults (%s) (Read-Only)")%'plugin-defaults.ini',
@@ -852,11 +853,11 @@ class PersonalIniTab(QWidget):
 
     def show_showcalcols(self):
         lines=[]#[('calibre_std_user_categories',_('User Categories'))]
-        for k,f in field_metadata.iteritems():
+        for k,f in six.iteritems(field_metadata):
             if f['name'] and k not in STD_COLS_SKIP: # only if it has a human readable name.
                 lines.append(('calibre_std_'+k,f['name']))
 
-        for k, column in self.plugin_action.gui.library_view.model().custom_columns.iteritems():
+        for k, column in six.iteritems(self.plugin_action.gui.library_view.model().custom_columns):
             if k != prefs['savemetacol']:
                 # custom always have name.
                 lines.append(('calibre_cust_'+k[1:],column['name']))
@@ -1354,7 +1355,7 @@ class CustomColumnsTab(QWidget):
         self.sl = QVBoxLayout()
         scrollcontent.setLayout(self.sl)
 
-        for key, column in custom_columns.iteritems():
+        for key, column in six.iteritems(custom_columns):
 
             if column['datatype'] in permitted_values:
                 # print("\n============== %s ===========\n"%key)
@@ -1407,7 +1408,7 @@ class CustomColumnsTab(QWidget):
         self.errorcol = QComboBox(self)
         self.errorcol.setToolTip(tooltip)
         self.errorcol.addItem('','none')
-        for key, column in custom_columns.iteritems():
+        for key, column in six.iteritems(custom_columns):
             if column['datatype'] in ('text','comments'):
                 self.errorcol.addItem(column['name'],key)
         self.errorcol.setCurrentIndex(self.errorcol.findData(prefs['errorcol']))
@@ -1431,7 +1432,7 @@ class CustomColumnsTab(QWidget):
         self.savemetacol = QComboBox(self)
         self.savemetacol.setToolTip(tooltip)
         self.savemetacol.addItem('','')
-        for key, column in custom_columns.iteritems():
+        for key, column in six.iteritems(custom_columns):
             if column['datatype'] in ('comments'):
                 self.savemetacol.addItem(column['name'],key)
         self.savemetacol.setCurrentIndex(self.savemetacol.findData(prefs['savemetacol']))
@@ -1451,7 +1452,7 @@ class CustomColumnsTab(QWidget):
         self.lastcheckedcol = QComboBox(self)
         self.lastcheckedcol.setToolTip(tooltip)
         self.lastcheckedcol.addItem('','none')
-        for key, column in custom_columns.iteritems():
+        for key, column in six.iteritems(custom_columns):
             if column['datatype'] == 'datetime':
                 self.lastcheckedcol.addItem(column['name'],key)
         self.lastcheckedcol.setCurrentIndex(self.lastcheckedcol.findData(prefs['lastcheckedcol']))
@@ -1494,7 +1495,7 @@ class StandardColumnsTab(QWidget):
         self.stdcol_newonlycheck = {}
 
         rows=[]
-        for key, column in columns.iteritems():
+        for key, column in six.iteritems(columns):
             row = []
             rows.append(row)
             label = QLabel(column)

--- a/calibre-plugin/config.py
+++ b/calibre-plugin/config.py
@@ -44,6 +44,7 @@ else:
 from calibre.gui2 import dynamic, info_dialog, question_dialog
 from calibre.gui2.ui import get_gui
 from calibre.gui2.complete2 import EditWithComplete
+from .fanficfare.six import text_type as unicode
 
 try:
     from calibre.ebooks.covers import generate_cover as cal_generate_cover
@@ -1667,5 +1668,3 @@ class ImapTab(QWidget):
         self.l.addWidget(label,row,0,1,-1,Qt.AlignTop)
         self.l.setRowStretch(row,1)
         row+=1
-
-

--- a/calibre-plugin/dialogs.py
+++ b/calibre-plugin/dialogs.py
@@ -491,7 +491,8 @@ class AddNewDialog(SizePersistedDialog):
                 retval['updatemeta']=True
                 retval['collision']=ADDNEW
 
-        return dict(retval.items() + self.extraoptions.items() )
+        retval.update(self.extraoptions)
+        return retval
 
     def get_urlstext(self):
         return unicode(self.url.toPlainText())

--- a/calibre-plugin/dialogs.py
+++ b/calibre-plugin/dialogs.py
@@ -55,6 +55,7 @@ from calibre.gui2 import gprefs
 show_download_options = 'fff:add new/update dialogs:show_download_options'
 from calibre.gui2.dialogs.confirm_delete import confirm
 from calibre.gui2.complete2 import EditWithComplete
+from .fanficfare.six import text_type as unicode
 
 # pulls in translation files for _() strings
 try:
@@ -707,7 +708,7 @@ class _LoopProgressDialog(QProgressDialog):
             book['good']=False
             book['status']=_("Error")
             book['comment']=unicode(e)
-            logger.error("Exception: %s:%s"%(book,unicode(e)),exc_info=True)
+            logger.error("Exception: %s:%s"%(book,book['comment']),exc_info=True)
 
         self.updateStatus()
         self.i += 1

--- a/calibre-plugin/dialogs.py
+++ b/calibre-plugin/dialogs.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (unicode_literals, division,
+from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
 __license__   = 'GPL v3'
@@ -74,7 +74,7 @@ from calibre_plugins.fanficfare_plugin.fanficfare.configurable \
     import (get_valid_sections, get_valid_entries,
             get_valid_keywords, get_valid_entry_keywords)
 
-from inihighlighter import IniHighlighter
+from .inihighlighter import IniHighlighter
 
 ## moved to prefs.py so they can be included in jobs.py.
 from calibre_plugins.fanficfare_plugin.prefs import \
@@ -1370,7 +1370,7 @@ class IniTextDialog(SizePersistedDialog):
         self.resize_dialog()
 
     def accept(self):
-        from fff_util import test_config
+        from .fff_util import test_config
 
         # print("in accept")
         errors = test_config(self.get_plain_text())

--- a/calibre-plugin/fff_plugin.py
+++ b/calibre-plugin/fff_plugin.py
@@ -7,6 +7,7 @@ __license__   = 'GPL v3'
 __copyright__ = '2019, Jim Miller'
 __docformat__ = 'restructuredtext en'
 
+from .fanficfare.six import text_type as unicode
 
 # import cProfile
 

--- a/calibre-plugin/fff_plugin.py
+++ b/calibre-plugin/fff_plugin.py
@@ -405,7 +405,7 @@ class FanFicFarePlugin(InterfaceAction):
         # get_resources will return a dictionary mapping names to bytes. Names that
         # are not found in the zip file will not be in the returned dictionary.
 
-        text = get_resources('about.html')
+        text = get_resources('about.html').decode('utf-8')
         AboutDialog(self.gui,self.qaction.icon(),self.version + text).exec_()
 
     def create_menu_item_ex(self, parent_menu, menu_text, image=None, tooltip=None,

--- a/calibre-plugin/fff_plugin.py
+++ b/calibre-plugin/fff_plugin.py
@@ -1055,7 +1055,7 @@ class FanFicFarePlugin(InterfaceAction):
         for x in range(0,2):
             try:
                 adapter.getStoryMetadataOnly(get_cover=False)
-            except exceptions.FailedToLogin, f:
+            except exceptions.FailedToLogin as f:
                 logger.warn("Login Failed, Need Username/Password.")
                 userpass = UserPassDialog(self.gui,url,f)
                 userpass.exec_() # exec_ will make it act modal

--- a/calibre-plugin/fff_plugin.py
+++ b/calibre-plugin/fff_plugin.py
@@ -27,7 +27,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 import os, copy, threading, re, platform, sys
-from StringIO import StringIO
+from io import BytesIO
 from functools import partial
 from datetime import datetime, time, date
 from string import Template
@@ -802,7 +802,7 @@ class FanFicFarePlugin(InterfaceAction):
         tdir = PersistentTemporaryDirectory(prefix='fff_anthology_')
         logger.debug("tdir:\n%s"%tdir)
 
-        bookepubio = StringIO(db.format(book_id,'EPUB',index_is_id=True))
+        bookepubio = BytesIO(db.format(book_id,'EPUB',index_is_id=True))
 
         filenames = self.get_epubmerge_plugin().do_unmerge(bookepubio,tdir)
         urlmapfile = {}
@@ -1362,7 +1362,7 @@ class FanFicFarePlugin(InterfaceAction):
                     # let it go and it will download it.
                     if db.has_format(book_id,fileform,index_is_id=True):
                         (epuburl,chaptercount) = \
-                            get_dcsource_chaptercount(StringIO(db.format(book_id,'EPUB',
+                            get_dcsource_chaptercount(BytesIO(db.format(book_id,'EPUB',
                                                                          index_is_id=True)))
                         #urlchaptercount = int(story.getMetadata('numChapters').replace(',',''))
                         # returns int adjusted for start-end range.
@@ -2736,4 +2736,3 @@ def pretty_book(d, indent=0, spacer='     '):
         return '\n'.join(['%s%s:\n%s' % (kindent, k, pretty_book(v, indent + 1, spacer))
                           for k, v in d.items()])
     return "%s%s"%(kindent, d)
-

--- a/calibre-plugin/fff_plugin.py
+++ b/calibre-plugin/fff_plugin.py
@@ -2,6 +2,8 @@
 
 from __future__ import (unicode_literals, division, absolute_import,
                         print_function)
+import six
+from six.moves import range
 
 __license__   = 'GPL v3'
 __copyright__ = '2019, Jim Miller'
@@ -32,7 +34,6 @@ from io import BytesIO
 from functools import partial
 from datetime import datetime, time, date
 from string import Template
-import urllib
 import email
 import traceback
 
@@ -237,7 +238,7 @@ class FanFicFarePlugin(InterfaceAction):
             for f in filelist.splitlines():
                 #print("filename:%s"%f)
                 if f.endswith(".eml"):
-                    fhandle = urllib.urlopen(f)
+                    fhandle = six.moves.urllib.request.urlopen(f)
                     msg = email.message_from_file(fhandle)
                     if msg.is_multipart():
                         for part in msg.walk():
@@ -1443,7 +1444,7 @@ class FanFicFarePlugin(InterfaceAction):
                         #logger.debug("%s(%s): %s"%(label,key,value))
 
                 # custom columns
-                for k, column in self.gui.library_view.model().custom_columns.iteritems():
+                for k, column in six.iteritems(self.gui.library_view.model().custom_columns):
                     if k != prefs['savemetacol']:
                         key='calibre_cust_'+k[1:]
                         label=column['name']
@@ -2027,7 +2028,7 @@ class FanFicFarePlugin(InterfaceAction):
         # implement 'newonly' flags here by setting to the current
         # value again.
         if not book['added']:
-            for (col,newonly) in prefs['std_cols_newonly'].iteritems():
+            for (col,newonly) in six.iteritems(prefs['std_cols_newonly']):
                 if newonly:
                     if col == "identifiers":
                         mi.set_identifiers(oldmi.get_identifiers())
@@ -2070,7 +2071,7 @@ class FanFicFarePlugin(InterfaceAction):
             self.set_custom(db, book_id, 'lastcheckedcol', book['timestamp'], label=label, commit=True)
 
         #print("prefs['custom_cols'] %s"%prefs['custom_cols'])
-        for col, meta in prefs['custom_cols'].iteritems():
+        for col, meta in six.iteritems(prefs['custom_cols']):
             #print("setting %s to %s"%(col,meta))
             if col not in custom_columns:
                 logger.debug("%s not an existing column, skipping."%col)
@@ -2305,7 +2306,7 @@ class FanFicFarePlugin(InterfaceAction):
                 #print("cover_path:%s"%cover_path)
                 opts = ALL_OPTS.copy()
                 opts.update(data)
-                O = namedtuple('Options', ' '.join(ALL_OPTS.iterkeys()))
+                O = namedtuple('Options', ' '.join(six.iterkeys(ALL_OPTS)))
                 opts = O(**opts)
 
                 log = Log(level=Log.DEBUG)
@@ -2626,7 +2627,7 @@ class FanFicFarePlugin(InterfaceAction):
                     book['all_metadata']['dateUpdated'] = b['all_metadata']['dateUpdated']
 
             # copy list all_metadata
-            for (k,v) in b['all_metadata'].iteritems():
+            for (k,v) in six.iteritems(b['all_metadata']):
                 #print("merge_meta_books v:%s k:%s"%(v,k))
                 if k in ('numChapters','numWords'):
                     if k in b['all_metadata'] and b['all_metadata'][k]:

--- a/calibre-plugin/fff_plugin.py
+++ b/calibre-plugin/fff_plugin.py
@@ -7,7 +7,7 @@ __license__   = 'GPL v3'
 __copyright__ = '2019, Jim Miller'
 __docformat__ = 'restructuredtext en'
 
-from .fanficfare.six import text_type as unicode
+from .fanficfare.six import string_types, text_type as unicode
 
 # import cProfile
 
@@ -857,7 +857,7 @@ class FanFicFarePlugin(InterfaceAction):
     def prep_anthology_downloads(self, options, update_books,
                                  merge=False, urlmapfile=None):
 
-        if isinstance(update_books,basestring):
+        if isinstance(update_books, string_types):
             url_list = split_text_to_urls(update_books)
             update_books = self.convert_urls_to_books(url_list)
 
@@ -966,7 +966,7 @@ class FanFicFarePlugin(InterfaceAction):
 
         logger.debug("add_tag:%s"%options.get('add_tag',None))
 
-        if isinstance(books,basestring):
+        if isinstance(books, string_types):
             url_list = split_text_to_urls(books)
             books = self.convert_urls_to_books(url_list)
 

--- a/calibre-plugin/fff_util.py
+++ b/calibre-plugin/fff_util.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 from calibre_plugins.fanficfare_plugin.fanficfare import adapters, exceptions
 from calibre_plugins.fanficfare_plugin.fanficfare.configurable import Configuration
 from calibre_plugins.fanficfare_plugin.prefs import prefs
+from .fanficfare.six import ensure_text
 from .fanficfare.six.moves import configparser
 
 def get_fff_personalini():
@@ -29,8 +30,8 @@ def get_fff_config(url,fileform="epub",personalini=None):
     except Exception as e:
         logger.debug("Failed trying to get ini config for url(%s): %s, using section %s instead"%(url,e,sections))
     configuration = Configuration(sections,fileform)
-    configuration.readfp(StringIO(get_resources("plugin-defaults.ini").decode('utf-8')))
-    configuration.readfp(StringIO(personalini.decode('utf-8')))
+    configuration.readfp(StringIO(ensure_text(get_resources("plugin-defaults.ini"))))
+    configuration.readfp(StringIO(ensure_text(personalini)))
 
     return configuration
 

--- a/calibre-plugin/fff_util.py
+++ b/calibre-plugin/fff_util.py
@@ -8,7 +8,6 @@ __copyright__ = '2015, Jim Miller'
 __docformat__ = 'restructuredtext en'
 
 from io import StringIO
-from ConfigParser import ParsingError
 
 import logging
 logger = logging.getLogger(__name__)
@@ -16,6 +15,7 @@ logger = logging.getLogger(__name__)
 from calibre_plugins.fanficfare_plugin.fanficfare import adapters, exceptions
 from calibre_plugins.fanficfare_plugin.fanficfare.configurable import Configuration
 from calibre_plugins.fanficfare_plugin.prefs import prefs
+from .fanficfare.six.moves import configparser
 
 def get_fff_personalini():
     return prefs['personal.ini']
@@ -42,7 +42,7 @@ def test_config(initext):
         configini = get_fff_config("test1.com?sid=555",
                                     personalini=initext)
         errors = configini.test_config()
-    except ParsingError as pe:
+    except configparser.ParsingError as pe:
         errors = pe.errors
 
     return errors

--- a/calibre-plugin/fff_util.py
+++ b/calibre-plugin/fff_util.py
@@ -7,7 +7,7 @@ __license__   = 'GPL v3'
 __copyright__ = '2015, Jim Miller'
 __docformat__ = 'restructuredtext en'
 
-from StringIO import StringIO
+from io import StringIO
 from ConfigParser import ParsingError
 
 import logging
@@ -29,8 +29,8 @@ def get_fff_config(url,fileform="epub",personalini=None):
     except Exception as e:
         logger.debug("Failed trying to get ini config for url(%s): %s, using section %s instead"%(url,e,sections))
     configuration = Configuration(sections,fileform)
-    configuration.readfp(StringIO(get_resources("plugin-defaults.ini")))
-    configuration.readfp(StringIO(personalini))
+    configuration.readfp(StringIO(get_resources("plugin-defaults.ini").decode('utf-8')))
+    configuration.readfp(StringIO(personalini.decode('utf-8')))
 
     return configuration
 
@@ -44,6 +44,5 @@ def test_config(initext):
         errors = configini.test_config()
     except ParsingError as pe:
         errors = pe.errors
-    
-    return errors
 
+    return errors

--- a/calibre-plugin/inihighlighter.py
+++ b/calibre-plugin/inihighlighter.py
@@ -14,6 +14,8 @@ try:
 except ImportError as e:
     from PyQt4.Qt import (Qt, QSyntaxHighlighter, QTextCharFormat, QBrush, QFont)
 
+from .fanficfare.six import string_types
+
 class IniHighlighter(QSyntaxHighlighter):
     '''
     QSyntaxHighlighter class for use with QTextEdit for highlighting
@@ -107,7 +109,7 @@ class HighlightingRule():
                   weight=QFont.Normal,
                   style=Qt.SolidPattern,
                   blocknum=0):
-        if isinstance(pattern,basestring):
+        if isinstance(pattern, string_types):
             self.pattern = re.compile(pattern)
         else:
             self.pattern=pattern

--- a/calibre-plugin/inihighlighter.py
+++ b/calibre-plugin/inihighlighter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import (unicode_literals, division,
+from __future__ import (absolute_import, unicode_literals, division,
                         print_function)
 
 __license__   = 'GPL v3'
@@ -19,11 +19,11 @@ class IniHighlighter(QSyntaxHighlighter):
     QSyntaxHighlighter class for use with QTextEdit for highlighting
     ini config files.
     '''
-    
+
     def __init__( self, parent, sections=[], keywords=[], entries=[], entry_keywords=[] ):
         QSyntaxHighlighter.__init__( self, parent )
         self.parent = parent
-        
+
         self.highlightingRules = []
 
         if entries:
@@ -33,7 +33,7 @@ class IniHighlighter(QSyntaxHighlighter):
 
         # true/false -- just to be nice.
         self.highlightingRules.append( HighlightingRule( r"\b(true|false)\b", Qt.darkGreen ) )
-        
+
         # *all* keywords -- change known later.
         self.errorRule = HighlightingRule( r"^[^:=\s][^:=]*[:=]", Qt.red )
         self.highlightingRules.append( self.errorRule )
@@ -70,7 +70,7 @@ class IniHighlighter(QSyntaxHighlighter):
 
         # NOT comments -- but can be custom columns, so don't flag.
         #self.highlightingRules.append( HighlightingRule( r"(?<!^)#[^\n]*" , Qt.red ) )
-        
+
         # comments -- comments must start from column 0.
         self.commentRule = HighlightingRule( r"^#[^\n]*" , Qt.darkYellow )
         self.highlightingRules.append( self.commentRule )
@@ -91,15 +91,15 @@ class IniHighlighter(QSyntaxHighlighter):
             # unknown section, error all:
             if blocknum == 1 and blocknum == self.previousBlockState():
                 self.setFormat( 0, len(text), self.errorRule.highlight )
-                
+
             # teststory section rules:
             if blocknum == 3:
                 self.setFormat( 0, len(text), self.teststoryRule.highlight )
-            
+
             # storyUrl section rules:
             if blocknum == 4:
                 self.setFormat( 0, len(text), self.storyUrlRule.highlight )
-            
+
         self.setCurrentBlockState( blocknum )
 
 class HighlightingRule():
@@ -117,4 +117,3 @@ class HighlightingRule():
         charfmt.setFontWeight(weight)
         self.highlight = charfmt
         self.blocknum=blocknum
-    

--- a/calibre-plugin/jobs.py
+++ b/calibre-plugin/jobs.py
@@ -2,6 +2,7 @@
 
 from __future__ import (unicode_literals, division, absolute_import,
                         print_function)
+import six
 
 __license__   = 'GPL v3'
 __copyright__ = '2018, Jim Miller, 2011, Grant Drake <grant.drake@gmail.com>'
@@ -323,7 +324,7 @@ def do_download_for_worker(book,options,merge,notification=lambda x,y:x):
                 data = {'smarten_punctuation':True}
                 opts = ALL_OPTS.copy()
                 opts.update(data)
-                O = namedtuple('Options', ' '.join(ALL_OPTS.iterkeys()))
+                O = namedtuple('Options', ' '.join(six.iterkeys(ALL_OPTS)))
                 opts = O(**opts)
 
                 log = Log(level=Log.DEBUG)
@@ -356,7 +357,7 @@ def inject_cal_cols(book,story,configuration):
     if 'calibre_columns' in book:
         injectini = ['[injected]']
         extra_valid = []
-        for k, v in book['calibre_columns'].iteritems():
+        for k, v in six.iteritems(book['calibre_columns']):
             story.setMetadata(k,v['val'])
             injectini.append('%s_label:%s'%(k,v['label']))
             extra_valid.append(k)

--- a/calibre-plugin/jobs.py
+++ b/calibre-plugin/jobs.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 import traceback
 from datetime import time
-from StringIO import StringIO
+from io import StringIO
 from collections import defaultdict
 
 from calibre.utils.ipc.server import Server
@@ -363,4 +363,3 @@ def inject_cal_cols(book,story,configuration):
             injectini.append("add_to_extra_valid_entries:,"+','.join(extra_valid))
             configuration.readfp(StringIO('\n'.join(injectini)))
             #print("added:\n%s\n"%('\n'.join(injectini)))
-

--- a/calibre-plugin/jobs.py
+++ b/calibre-plugin/jobs.py
@@ -19,6 +19,7 @@ from calibre.utils.ipc.server import Server
 from calibre.utils.ipc.job import ParallelJob
 from calibre.constants import numeric_version as calibre_version
 from calibre.utils.date import local_tz
+from .fanficfare.six import text_type as unicode
 
 from calibre_plugins.fanficfare_plugin.wordcount import get_word_count
 from calibre_plugins.fanficfare_plugin.prefs import (SAVE_YES, SAVE_YES_UNLESS_SITE)
@@ -341,7 +342,7 @@ def do_download_for_worker(book,options,merge,notification=lambda x,y:x):
             book['comment']=unicode(e)
             book['icon']='dialog_error.png'
             book['status'] = _('Error')
-            logger.info("Exception: %s:%s"%(book,unicode(e)),exc_info=True)
+            logger.info("Exception: %s:%s"%(book,book['comment']),exc_info=True)
 
         #time.sleep(10)
     return book

--- a/calibre-plugin/wordcount.py
+++ b/calibre-plugin/wordcount.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 import re
 
 from calibre.ebooks.oeb.iterator import EbookIterator
+from .fanficfare.six import text_type as unicode
 
 RE_HTML_BODY = re.compile(u'<body[^>]*>(.*)</body>', re.UNICODE | re.DOTALL | re.IGNORECASE)
 RE_STRIP_MARKUP = re.compile(u'<[^>]+>', re.UNICODE)
@@ -28,7 +29,7 @@ def get_word_count(book_path):
     Estimate a word count
     '''
     from calibre.utils.localization import get_lang
-    
+
     iterator = _open_epub_file(book_path)
 
     lang = iterator.opf.language
@@ -52,7 +53,7 @@ def _get_epub_standard_word_count(iterator, lang='en'):
     '''
 
     book_text = _read_epub_contents(iterator, strip_html=True)
-    
+
     try:
         from calibre.spell.break_iterator import count_words
         wordcount = count_words(book_text, lang)
@@ -67,7 +68,7 @@ def _get_epub_standard_word_count(iterator, lang='en'):
             wordcount = get_wordcount_obj(book_text)
             wordcount = wordcount.words
             logger.debug('\tWord count - old method:%s'%wordcount)
-    
+
     return wordcount
 
 def _read_epub_contents(iterator, strip_html=False):
@@ -92,4 +93,3 @@ def _extract_body_text(data):
     if body:
         return RE_STRIP_MARKUP.sub('', body[0]).replace('.','. ')
     return ''
-

--- a/fanficfare/cli.py
+++ b/fanficfare/cli.py
@@ -17,6 +17,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from io import StringIO
 from optparse import OptionParser, SUPPRESS_HELP
 from os.path import expanduser, join, dirname
 from os import access, R_OK
@@ -61,7 +62,6 @@ try:
     from calibre_plugins.fanficfare_plugin.fanficfare.epubutils import (
         get_dcsource_chaptercount, get_update_data, reset_orig_chapters_epub)
     from calibre_plugins.fanficfare_plugin.fanficfare.geturls import get_urls_from_page, get_urls_from_imap
-    from calibre_plugins.fanficfare_plugin.fanficfare.six import StringIO
     from calibre_plugins.fanficfare_plugin.fanficfare.six.moves import configparser
     from calibre_plugins.fanficfare_plugin.fanficfare.six.moves import http_cookiejar as cl
 except ImportError:
@@ -70,7 +70,6 @@ except ImportError:
     from fanficfare.epubutils import (
         get_dcsource_chaptercount, get_update_data, reset_orig_chapters_epub)
     from fanficfare.geturls import get_urls_from_page, get_urls_from_imap
-    from fanficfare.six import StringIO
     from fanficfare.six.moves import configparser
     from fanficfare.six.moves import http_cookiejar as cl
 

--- a/fanficfare/epubutils.py
+++ b/fanficfare/epubutils.py
@@ -16,7 +16,7 @@ from xml.dom.minidom import parseString
 # py2 vs py3 transition
 from .six import ensure_text, text_type as unicode
 from .six import string_types as basestring
-from .six import BytesIO # StringIO under py2
+from io import BytesIO
 
 import bs4
 

--- a/fanficfare/mobi.py
+++ b/fanficfare/mobi.py
@@ -14,7 +14,7 @@ import logging
 from .six import text_type as unicode
 from .six import string_types as basestring
 from .six import ensure_binary
-from .six import BytesIO # StringIO under py2
+from io import BytesIO
 
 logger = logging.getLogger(__name__)
 

--- a/fanficfare/writers/base_writer.py
+++ b/fanficfare/writers/base_writer.py
@@ -29,7 +29,7 @@ from .. import six
 from ..six import text_type as unicode
 from ..six import ensure_text
 from ..six import ensure_binary
-from ..six import BytesIO # StringIO under py2
+from io import BytesIO
 
 from ..configurable import Configurable
 from ..htmlcleanup import removeEntities, removeAllEntities, stripHTML
@@ -257,4 +257,3 @@ class BaseStoryWriter(Configurable):
     def writeStoryImpl(self, out):
         "Must be overriden by sub classes."
         pass
-

--- a/fanficfare/writers/writer_epub.py
+++ b/fanficfare/writers/writer_epub.py
@@ -27,7 +27,7 @@ import re
 from ..six import text_type as unicode
 from ..six import string_types as basestring
 from ..six import ensure_binary
-from ..six import BytesIO # StringIO under py2
+from io import BytesIO
 
 ## XML isn't as forgiving as HTML, so rather than generate as strings,
 ## use DOM to generate the XML files.
@@ -771,4 +771,3 @@ def newTag(dom,name,attrs=None,text=None):
     if( text is not None ):
         tag.appendChild(dom.createTextNode(text))
     return tag
-

--- a/fanficfare/writers/writer_mobi.py
+++ b/fanficfare/writers/writer_mobi.py
@@ -16,6 +16,7 @@
 #
 
 from __future__ import absolute_import
+from io import BytesIO
 import logging
 import string
 
@@ -23,9 +24,6 @@ from .base_writer import *
 from ..htmlcleanup import stripHTML
 from ..mobi import Converter
 from ..exceptions import FailedToWriteOutput
-
-# py2 vs py3 transition
-from ..six import BytesIO # StringIO under py2
 
 logger = logging.getLogger(__name__)
 
@@ -116,7 +114,7 @@ ${value}<br />
     def writeStoryImpl(self, out):
 
         files = []
-        
+
         # write title page.
         if self.getConfig("titlepage_use_table"):
             TITLE_PAGE_START  = self.MOBI_TABLE_TITLE_PAGE_START
@@ -130,7 +128,7 @@ ${value}<br />
             WIDE_TITLE_ENTRY  = self.MOBI_TITLE_ENTRY # same, only wide in tables.
             NO_TITLE_ENTRY    = self.MOBI_NO_TITLE_ENTRY
             TITLE_PAGE_END    = self.MOBI_TITLE_PAGE_END
-        
+
         titlepageIO = BytesIO()
         self.writeTitlePage(out=titlepageIO,
                             START=TITLE_PAGE_START,
@@ -144,7 +142,7 @@ ${value}<br />
 
         ## MOBI always has a TOC injected by mobi.py because there's
         ## no meta-data TOC.
-        # # write toc page.  
+        # # write toc page.
         # tocpageIO = BytesIO()
         # self.writeTOCPage(tocpageIO,
         #                   self.MOBI_TOC_PAGE_START,
@@ -158,12 +156,12 @@ ${value}<br />
             CHAPTER_START = string.Template(self.getConfig("chapter_start"))
         else:
             CHAPTER_START = self.MOBI_CHAPTER_START
-        
+
         if self.hasConfig('chapter_end'):
             CHAPTER_END = string.Template(self.getConfig("chapter_end"))
         else:
             CHAPTER_END = self.MOBI_CHAPTER_END
-        
+
         for index, chap in enumerate(self.story.getChapters()):
             if chap['html']:
                 logger.debug('Writing chapter text for: %s' % chap['title'])
@@ -183,7 +181,7 @@ ${value}<br />
         if len(mobidata) < 1:
             raise FailedToWriteOutput("Zero length mobi output")
         out.write(mobidata)
-        
+
         del files
         del mobidata
 
@@ -196,4 +194,3 @@ def newTag(dom,name,attrs=None,text=None):
     if( text is not None ):
         tag.appendChild(dom.createTextNode(text))
     return tag
-    

--- a/webservice/main.py
+++ b/webservice/main.py
@@ -28,7 +28,7 @@ import urllib
 import datetime
 
 import traceback
-from StringIO import StringIO
+from io import StringIO
 
 from google.appengine.ext import db
 from google.appengine.api import taskqueue
@@ -59,7 +59,7 @@ class UserConfigServer(webapp2.RequestHandler):
         if l and l[0].config:
             uconfig=l[0]
             #logging.debug('reading config from UserConfig(%s)'%uconfig.config)
-            configuration.readfp(StringIO(uconfig.config))
+            configuration.readfp(StringIO(uconfig.config.decode('utf-8')))
 
         return configuration
 
@@ -512,7 +512,7 @@ class FanfictionDownloaderTask(UserConfigServer):
 
             allmeta = adapter.getStory().getAllMetadata(removeallentities=True,doreplacements=False)
 
-            outbuffer = StringIO()
+            outbuffer = BytesIO()
             writer.writeStory(outbuffer)
             data = outbuffer.getvalue()
             outbuffer.close()


### PR DESCRIPTION
This is not a complete port, but it does get the plugin closer to python3 support. Specifically, it now imports correctly during calibre initialization. Syntax-level issues were cleared up, and I've done a tree-wide cleanup of the StringIO module.