### PR TITLE
adapter_asianfanficscom: fix missing HTML tags by automatically subscribing to story

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -2163,6 +2163,11 @@ include_in_category:tags
 ## chapter_start to remove the standard chapter title, as shown below.
 inject_chapter_title:false
 
+## This website removes certain HTML tags and portions of the story
+## from subscriber-only stories. It is strongly recommended to turn
+## this option on.
+auto_sub:false
+
 [www.bdsmlibrary.com]
 ## Some sites also require the user to confirm they are adult for
 ## adult content.  Uncomment by removing '#' in front of is_adult.

--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -2133,10 +2133,11 @@ strip_text_links:true
 
 [www.asianfanfics.com]
 ## Unlike most sites, asianfanfics.com, instead of denying access to
-## 'adult' content, will censor the text of stories to remove the
-## 'adult' words.  FanFicFare cannot detect when this happens, but if
-## you set your username and password, FFF will log you in to prevent
-## that.
+## 'adult' or subscriber-only content, will censor the text of stories
+## to remove 'adult' words or entire portions of the text. This is why
+## an account is required to download stories from this site. It is
+## also strongly recommended to consider enabling auto_sub in order to
+## further avoid this from happening.
 #username:YourName
 #password:yourpassword
 
@@ -2165,7 +2166,10 @@ inject_chapter_title:false
 
 ## This website removes certain HTML tags and portions of the story
 ## from subscriber-only stories. It is strongly recommended to turn
-## this option on.
+## this option on. This will automatically subscribe you to such
+## stories in order to acquire the unaltered text. You can
+## unsubscribe manually on the website after the story has been
+## downloaded.
 auto_sub:false
 
 [www.bdsmlibrary.com]

--- a/fanficfare/adapters/adapter_asianfanficscom.py
+++ b/fanficfare/adapters/adapter_asianfanficscom.py
@@ -137,7 +137,7 @@ class AsianFanFicsComAdapter(BaseSiteAdapter):
         # adult check
         adultCheck = soup.find('form',{'action':'/account/toggle_age'})
         if adultCheck:
-           logger.info('This story is marked as mature. It is recommended to log in, as this website censors text otherwise.') 
+           logger.info('This story is marked as mature. It is recommended to log in, as this website censors text otherwise.')
 
         # subscription check
         loginCheck = soup.find('div',{'id':'login'})

--- a/fanficfare/adapters/adapter_asianfanficscom.py
+++ b/fanficfare/adapters/adapter_asianfanficscom.py
@@ -160,7 +160,7 @@ class AsianFanFicsComAdapter(BaseSiteAdapter):
             self.performLogin(url,soup)
             data = self._fetchUrl(url,usecache=False)
             soup = self.make_soup(data)
-        elif "Logout" not in data:
+        elif loginCheck:
             logger.info('Note: Logging in is highly recommended, as this website censors text and removes certain HTML tags if not logged in.')
 
         # adult check

--- a/fanficfare/adapters/base_adapter.py
+++ b/fanficfare/adapters/base_adapter.py
@@ -279,9 +279,6 @@ class BaseSiteAdapter(Configurable):
             if self.logfile:
                 self.story.logfile = self.logfile
 
-            # only called when not self.storyDone
-            self.hookFinalCleanup()
-
         # logger.debug(u"getStory times:\n%s"%self.times)
         return self.story
 
@@ -383,10 +380,6 @@ class BaseSiteAdapter(Configurable):
 
     def getChapterText(self, url):
         "Needs to be overriden in each adapter class."
-        pass
-
-    def hookFinalCleanup(self):
-        "Usually not needed."
         pass
 
     # Just for series, in case we choose to change how it's stored or represented later.

--- a/fanficfare/adapters/base_adapter.py
+++ b/fanficfare/adapters/base_adapter.py
@@ -279,6 +279,9 @@ class BaseSiteAdapter(Configurable):
             if self.logfile:
                 self.story.logfile = self.logfile
 
+            # only called when not self.storyDone
+            self.hookFinalCleanup()
+
         # logger.debug(u"getStory times:\n%s"%self.times)
         return self.story
 
@@ -380,6 +383,10 @@ class BaseSiteAdapter(Configurable):
 
     def getChapterText(self, url):
         "Needs to be overriden in each adapter class."
+        pass
+
+    def hookFinalCleanup(self):
+        "Usually not needed."
         pass
 
     # Just for series, in case we choose to change how it's stored or represented later.

--- a/fanficfare/configurable.py
+++ b/fanficfare/configurable.py
@@ -243,6 +243,8 @@ def get_valid_set_options():
                'description_in_chapter':(['literotica.com'],None,boollist),
 
                'inject_chapter_title':(['asianfanfics.com'],None,boollist),
+               
+               'auto_sub':(['asianfanfics.com'],None,boollist),
 
                # eFiction Base adapters allow bulk_load
                # kept forgetting to add them, so now it's automatic.
@@ -441,6 +443,7 @@ def get_valid_keywords():
                  'conditionals_use_lists',
                  'description_in_chapter',
                  'inject_chapter_title',
+                 'auto_sub',
                  'titlepage_end',
                  'titlepage_entries',
                  'titlepage_entry',

--- a/fanficfare/configurable.py
+++ b/fanficfare/configurable.py
@@ -243,7 +243,7 @@ def get_valid_set_options():
                'description_in_chapter':(['literotica.com'],None,boollist),
 
                'inject_chapter_title':(['asianfanfics.com'],None,boollist),
-               
+
                'auto_sub':(['asianfanfics.com'],None,boollist),
 
                # eFiction Base adapters allow bulk_load

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -2197,10 +2197,10 @@ include_in_category:tags
 ## chapter_start to remove the standard chapter title, as shown below.
 inject_chapter_title:false
 
-## This website removes certain HTML tags if the user is not
-## subscribed to the story. This is done by default. If you'd rather
-## not be automatically subbed to stories, change this to false.
-auto_sub:true
+## This website removes certain HTML tags and portions of the story
+## from subscriber-only stories. It is strongly recommended to turn
+## this option on.
+auto_sub:false
 
 [www.bdsmlibrary.com]
 ## Some sites also require the user to confirm they are adult for

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -2167,10 +2167,11 @@ strip_text_links:true
 
 [www.asianfanfics.com]
 ## Unlike most sites, asianfanfics.com, instead of denying access to
-## 'adult' content, will censor the text of stories to remove the
-## 'adult' words.  FanFicFare cannot detect when this happens, but if
-## you set your username and password, FFF will log you in to prevent
-## that.
+## 'adult' or subscriber-only content, will censor the text of stories
+## to remove 'adult' words or entire portions of the text. This is why
+## an account is required to download stories from this site. It is
+## also strongly recommended to consider enabling auto_sub in order to
+## further avoid this from happening.
 #username:YourName
 #password:yourpassword
 
@@ -2199,7 +2200,10 @@ inject_chapter_title:false
 
 ## This website removes certain HTML tags and portions of the story
 ## from subscriber-only stories. It is strongly recommended to turn
-## this option on.
+## this option on. This will automatically subscribe you to such
+## stories in order to acquire the unaltered text. You can
+## unsubscribe manually on the website after the story has been
+## downloaded.
 auto_sub:false
 
 [www.bdsmlibrary.com]

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -2197,6 +2197,11 @@ include_in_category:tags
 ## chapter_start to remove the standard chapter title, as shown below.
 inject_chapter_title:false
 
+## This website removes certain HTML tags if the user is not
+## subscribed to the story. This is done by default. If you'd rather
+## not be automatically subbed to stories, change this to false.
+auto_sub:true
+
 [www.bdsmlibrary.com]
 ## Some sites also require the user to confirm they are adult for
 ## adult content.  Uncomment by removing '#' in front of is_adult.


### PR DESCRIPTION
After pushing the previous fix, I've accidentally stumbled upon a bizarre check in adapter_asianfanficscom where the json file containing the story is missing (mostly style-related) HTML tags such as em if the user is not subscribed to the story. This is my attempt at getting around this nonsense by automatically subscribing before the story is downloaded.
I've also changed the login check to something a bit more error-proof.