### PR TITLE
Polish up the readme a bit, and advertise Pillow support in setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ plugin](http://www.mobileread.com/forums/showthread.php?p=3084025), a
 [command-line interface](https://pypi.python.org/pypi/FanFicFare) (via
 pip), and a [web service](http://fanficfare.appspot.com/).
 
+The cli version can also be obtained on Arch Linux from the official repositories:
+
+```
+pacman -S fanficfare
+```
+
+or from git via the [AUR package](https://aur.archlinux.org/packages/fanficfare-git)
+(which will also update the calibre plugin, if calibre is installed).
+
 There's additional info in the project
 [wiki](https://github.com/JimmXinu/FanFicFare/wiki) pages.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,36 @@
-FanFicFare
+[FanFicFare](https://github.com/JimmXinu/FanFicFare)
 ==========
 
-[This is the repository for the FanFicFare project.](https://github.com/JimmXinu/FanFicFare)
+FanFicFare makes reading stories from various websites much easier by helping
+you download them to EBook files.
 
-FanFicFare is the rename and move of the previous FanFictionDownLoader (AKA
-FFDL, AKA fanficdownloader) project.
+FanFicFare was previously known as FanFictionDownLoader (AKA
+FFDL, AKA fanficdownloader).
+
+Main features:
+
+- Download FanFiction stories from over 150 different sites into ebooks.
+  [Supported sites list](https://github.com/JimmXinu/FanFicFare/wiki/SupportedSites).
+
+- Update existing EPUB format ebooks, downloading only new chapters.
+
+- Get Story URLs from Web Page.
+
+- Support for downloading images in the story text. (EPUB and HTML
+  only -- download EPUB and convert to AZW3 for Kindle) More details on
+  configuring images in stories and cover images can be found in the
+  [FAQs] or [this post in the old FFDL thread].
+
+- Support for cover image. (EPUB only)
+
+- Optionally keep an Update Log of past updates (EPUB only).
+
+There's additional info in the project [wiki] pages.
+
+There's also a [FanFicFare maillist] for discussion and announcements.
+
+Getting FanFicFare
+==================
 
 This program is available as a [calibre
 plugin](http://www.mobileread.com/forums/showthread.php?p=3084025), a
@@ -20,9 +46,9 @@ pacman -S fanficfare
 or from git via the [AUR package](https://aur.archlinux.org/packages/fanficfare-git)
 (which will also update the calibre plugin, if calibre is installed).
 
-There's additional info in the project
-[wiki](https://github.com/JimmXinu/FanFicFare/wiki) pages.
 
-There's also a [FanFicFare
-maillist](https://groups.google.com/group/fanfic-downloader) for
-discussion and announcements.
+
+[this post in the old FFDL thread]: https://www.mobileread.com/forums/showthread.php?p=1982785#post1982785
+[FAQs]: https://github.com/JimmXinu/FanFicFare/wiki/FAQs#can-fanficfare-download-a-story-containing-images
+[FanFicFare maillist]: https://groups.google.com/group/fanfic-downloader
+[wiki]: https://github.com/JimmXinu/FanFicFare/wiki

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ setup(
     # for example:
     # $ pip install -e .[dev,test]
     extras_require={
+        'image_processing': ['Pillow'],
         # 'dev': ['check-manifest'],
         # 'test': ['coverage'],
     },


### PR DESCRIPTION
The first two changes I simply forgot about for a while, but, it would be convenient to let people know when/where fanficfare can be installed. I took the opportunity to make the readme stop over-focusing on what it used to be called, and start focusing on what the project can do for you.

The third commit is inspired by https://bugs.archlinux.org/task/63089, because I didn't realize that fanficfare could optionally use Pillow but didn't have it by default, until a user reported this sub-optimal condition. ;) So, advertise this in setup.py for more visibility.