### PR TITLE
fix newly introduced python3 compat error: 'unicode' doesn't exist

### DIFF
--- a/fanficfare/cli.py
+++ b/fanficfare/cli.py
@@ -29,6 +29,8 @@ import string
 import os, sys
 import pickle
 
+from .six import text_type as unicode
+
 if sys.version_info < (2, 7):
     sys.exit('This program requires Python 2.7 or newer.')
 elif sys.version_info < (3, 0):


### PR DESCRIPTION
In commit 50921e04356c007f4697070d4d28a49d334eb609, the unicode cast was added to fix passed_defaultsini being native str() type on python2 only. However it won't work at all on python3, since we need to import six.text_type for that.

This could be more consistently spotted if we used a different name, such as unicode_type or text_type itself, but instead we merely shadow the python2 type, which means mistakes still work on python2. :(