### PR TITLE
cli.py: allow multiple output formats; upgrade from optparse to argparse

### DIFF
--- a/fanficfare/configurable.py
+++ b/fanficfare/configurable.py
@@ -519,7 +519,7 @@ def make_generate_cover_settings(param):
 
 class Configuration(configparser.SafeConfigParser):
 
-    def __init__(self, sections, fileform, lightweight=False):
+    def __init__(self, sections, fileforms, lightweight=False):
         site = sections[-1] # first section is site DN.
         configparser.SafeConfigParser.__init__(self)
 
@@ -546,14 +546,15 @@ class Configuration(configparser.SafeConfigParser):
         self.addConfigSection(sitewith)
         self.addConfigSection(sitewithout)
 
-        if fileform:
-            self.addConfigSection(fileform)
-            ## add other sections:fileform (not including site DN)
-            ## after fileform, but before site-specific:fileform.
-            for section in sections[:-1]:
-                self.addConfigSection(section+":"+fileform)
-            self.addConfigSection(sitewith+":"+fileform)
-            self.addConfigSection(sitewithout+":"+fileform)
+        if fileforms:
+            for fileform in fileforms:
+                self.addConfigSection(fileform)
+                ## add other sections:fileform (not including site DN)
+                ## after fileform, but before site-specific:fileform.
+                for section in sections[:-1]:
+                    self.addConfigSection(section+":"+fileform)
+                self.addConfigSection(sitewith+":"+fileform)
+                self.addConfigSection(sitewithout+":"+fileform)
         self.addConfigSection("overrides")
 
         self.listTypeEntries = get_valid_list_entries()

--- a/fanficfare/configurable.py
+++ b/fanficfare/configurable.py
@@ -547,6 +547,9 @@ class Configuration(configparser.SafeConfigParser):
         self.addConfigSection(sitewithout)
 
         if fileforms:
+            if not isinstance(fileforms, (list, tuple)):
+                # convert for backwards compatibility
+                fileforms = [fileforms]
             for fileform in fileforms:
                 self.addConfigSection(fileform)
                 ## add other sections:fileform (not including site DN)


### PR DESCRIPTION
Hello,

this PR makes 2 changes:

- upgrade CLI argument parsing from `optparse` (deprecated) to `argparse`.
- allow multiple `--format` options to be specified. Example: `fanficfare --format epub --format html someurl> <some other url>`. This allows downloading stories in multiple formats while only fetching the content once.

**Limitations**
- I was not sure how to deal with the metadata `output_filename` value, since multiple files can be written. The new behavior will keep `output_filename` when a single file was written and uses `output_filenames` when multiple files were written. Would using comma/semicolon separated `output_filename` value make more sense?
- Most `epub` exclusive actions (e.g. `--update-epub`) will only work when no other format is specified. Example: `fanficfare --update-epub --format epub --format html my_epub.epub` will **not** work.
- `fanficfare.cli.main()` will now expect an `argparse.ArgumentParser` instead of an `optparse.OptionParser`, for the `parser` parameter, which may break compatibility with other scripts. Within fff, I could not find a single case where the `parser` argument was specified.
- The `fileform`parameter of `fanficfare.configurable.Configuration` has been renamed to `fileforms`. This may break compatibility when specified as a keyword argument, but compatibility is otherwise ensured.

**Tests**
The following tests were done to check for bugs:
- tested correct argument parsing (defaults, single format, multiple format)
- tested a download with multiple writers
- (limited) test of `--update-epub`. Since I had no epub which needed an update, the actual updates were skipped.
- (limited) test with calibre. It seems to work?