### PR TITLE
Added support for scribblehub

### DIFF
--- a/fanficfare/adapters/__init__.py
+++ b/fanficfare/adapters/__init__.py
@@ -170,6 +170,7 @@ from . import adapter_archivehpfanfictalkcom
 from . import adapter_scifistoriescom
 from . import adapter_silmarillionwritersguildorg
 from . import adapter_chireadscom
+from . import adapter_scribblehubcom
 
 ## This bit of complexity allows adapters to be added by just adding
 ## importing.  It eliminates the long if/else clauses we used to need

--- a/fanficfare/adapters/adapter_scribblehubcom.py
+++ b/fanficfare/adapters/adapter_scribblehubcom.py
@@ -1,0 +1,321 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2014 Fanficdownloader team, 2018 FanFicFare team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Software: eFiction
+from __future__ import absolute_import
+import logging
+logger = logging.getLogger(__name__)
+import re
+from ..htmlcleanup import stripHTML
+from .. import exceptions as exceptions
+
+# py2 vs py3 transition
+from ..six import text_type as unicode
+from ..six.moves.urllib.error import HTTPError
+
+from .base_adapter import BaseSiteAdapter,  makeDate
+
+# In general an 'adapter' needs to do these five things:
+
+# - 'Register' correctly with the downloader
+# - Site Login (if needed)
+# - 'Are you adult?' check (if needed--some do one, some the other, some both)
+# - Grab the chapter list
+# - Grab the story meta-data (some (non-eFiction) adapters have to get it from the author page)
+# - Grab the chapter texts
+
+# Search for XXX comments--that's where things are most likely to need changing.
+
+# This function is called by the downloader in all adapter_*.py files
+# in this dir to register the adapter class.  So it needs to be
+# updated to reflect the class below it.  That, plus getSiteDomain()
+# take care of 'Registering'.
+def getClass():
+    return ScribbleHubComAdapter # XXX
+
+# Class name has to be unique.  Our convention is camel case the
+# sitename with Adapter at the end.  www is skipped.
+class ScribbleHubComAdapter(BaseSiteAdapter): # XXX
+
+    def __init__(self, config, url):
+        BaseSiteAdapter.__init__(self, config, url)
+
+        self.username = "NoneGiven" # if left empty, site doesn't return any message at all.
+        self.password = ""
+        self.is_adult=False
+
+        # get storyId from url--url validation guarantees query is only sid=1234
+        # print(url)
+        # print(self.parsedUrl.query.split("series/",)[1])
+    #     self.story.setMetadata('storyId',self.parsedUrl.query.split('=',)[1])
+
+
+        # normalized story URL.
+        # XXX Most sites don't have the /fanfic part.  Replace all to remove it usually.
+        # self._setURL('http://' + self.getSiteDomain() + '/viewstory.php?sid='+self.story.getMetadata('storyId'))
+        print(url)
+        self._setURL(url)
+
+        # Each adapter needs to have a unique site abbreviation.
+        self.story.setMetadata('siteabbrev','shcom') # XXX
+
+        # The date format will vary from site to site.
+        # http://docs.python.org/library/datetime.html#strftime-strptime-behavior
+        self.dateformat = "%b %d, %Y" # XXX
+
+    @staticmethod # must be @staticmethod, don't remove it.
+    def getSiteDomain():
+        # The site domain.  Does have www here, if it uses it.
+        return 'www.scribblehub.com' # XXX
+
+    @classmethod
+    def getSiteExampleURLs(cls):
+        return "https://"+cls.getSiteDomain()+"/series/1234"
+
+    def getSiteURLPattern(self):
+        return re.escape("https://"+self.getSiteDomain()+"/series/")+r"\d+$"
+
+    ## Login seems to be reasonably standard across eFiction sites.
+    def needToLoginCheck(self, data):
+        if 'Registered Users Only' in data \
+                or 'There is no such account on our website' in data \
+                or "That password doesn't match the one in our database" in data:
+            return True
+        else:
+            return False
+
+    def performLogin(self, url):
+        params = {}
+
+        if self.password:
+            params['penname'] = self.username
+            params['password'] = self.password
+        else:
+            params['penname'] = self.getConfig("username")
+            params['password'] = self.getConfig("password")
+        params['cookiecheck'] = '1'
+        params['submit'] = 'Submit'
+
+        loginUrl = 'http://' + self.getSiteDomain() + '/user.php?action=login'
+        logger.debug("Will now login to URL (%s) as (%s)" % (loginUrl,
+                                                              params['penname']))
+
+        d = self._fetchUrl(loginUrl, params)
+
+        if "Member Account" not in d : #Member Account
+            logger.info("Failed to login to URL %s as %s" % (loginUrl,
+                                                              params['penname']))
+            raise exceptions.FailedToLogin(url,params['penname'])
+            return False
+        else:
+            return True
+
+         ## Getting the chapter list and the meta data, plus 'is adult' checking.
+    def extractChapterUrlsAndMetadata(self):
+
+        if self.is_adult or self.getConfig("is_adult"):
+            # Weirdly, different sites use different warning numbers.
+            # If the title search below fails, there's a good chance
+            # you need a different number.  print data at that point
+            # and see what the 'click here to continue' url says.
+            addurl = "&ageconsent=ok&warning=3"
+        else:
+            addurl=""
+
+        # index=1 makes sure we see the story chapter index.  Some
+        # sites skip that for one-chapter stories.
+        url = self.url
+        logger.debug("URL: "+url)
+
+        try:
+            data = self._fetchUrl(url)
+        except HTTPError as e:
+            if e.code == 404:
+                raise exceptions.StoryDoesNotExist(self.url)
+            else:
+                raise e
+
+        if self.needToLoginCheck(data):
+            # need to log in for this one.
+            self.performLogin(url)
+            data = self._fetchUrl(url)
+
+        m = re.search(r"'viewstory.php\?sid=\d+((?:&amp;ageconsent=ok)?&amp;warning=\d+)'",data)
+        if m != None:
+            if self.is_adult or self.getConfig("is_adult"):
+                # We tried the default and still got a warning, so
+                # let's pull the warning number from the 'continue'
+                # link and reload data.
+                addurl = m.group(1)
+                # correct stupid &amp; error in url.
+                addurl = addurl.replace("&amp;","&")
+                url = self.url+'&index=1'+addurl
+                logger.debug("URL 2nd try: "+url)
+
+                try:
+                    data = self._fetchUrl(url)
+                except HTTPError as e:
+                    if e.code == 404:
+                        raise exceptions.StoryDoesNotExist(self.url)
+                    else:
+                        raise e
+            else:
+                raise exceptions.AdultCheckRequired(self.url)
+
+        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
+            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+
+        # use BeautifulSoup HTML parser to make everything easier to find.
+        soup = self.make_soup(data)
+        # print data
+
+        # Now go hunting for all the meta data and the chapter list.
+
+        ## Title
+        pagetitle = soup.find('div',{'class':'fic_title'})
+        self.story.setMetadata('title',stripHTML(pagetitle))
+
+        # Find authorid and URL from... author url.
+        self.story.setMetadata('authorId',stripHTML(soup.find('span',{'class':'auth_name_fic'})))
+        self.story.setMetadata('authorUrl',soup.find('div',{'class':'author'}).find('div',{'property':'author'}).find('span',{'property':'name'}).find('a').get('href'))
+        self.story.setMetadata('author',stripHTML(soup.find('span',{'class':'auth_name_fic'})))
+
+        # Find the chapters:
+        # This is where scribblehub is gonna get a lil bit messy..
+        
+        # Chapter 1 is linked from the main page
+        chapter1_url = soup.find('div',{'class':'read_buttons'}).find('a').get('href')
+        soup = self.make_soup(chapter1_url)
+        self.add_chapter(soup.find('div',{'class':'chapter-title'}), chapter1_url)
+
+        # for chapter in soup.findAll('a', href=re.compile(r'viewstory.php\?sid='+self.story.getMetadata('storyId')+"&chapter=\d+$")):
+        #     # just in case there's tags, like <i> in chapter titles.
+        #     self.add_chapter(chapter,'http://'+self.host+'/'+chapter['href']+addurl)
+
+
+        # eFiction sites don't help us out a lot with their meta data
+        # formating, so it's a little ugly.
+
+        # utility method
+        def defaultGetattr(d,k):
+            try:
+                return d[k]
+            except:
+                return ""
+
+        # <span class="label">Rated:</span> NC-17<br /> etc
+        labels = soup.findAll('span',{'class':'label'})
+        for labelspan in labels:
+            value = labelspan.nextSibling
+            label = labelspan.string
+
+            if 'Summary' in label:
+                ## Everything until the next span class='label'
+                svalue = ""
+                while value and 'label' not in defaultGetattr(value,'class'):
+                    svalue += unicode(value)
+                    value = value.nextSibling
+                self.setDescription(url,svalue)
+                #self.story.setMetadata('description',stripHTML(svalue))
+
+            if 'Rated' in label:
+                self.story.setMetadata('rating', value)
+
+            if 'Word count' in label:
+                self.story.setMetadata('numWords', value)
+
+            if 'Categories' in label:
+                cats = labelspan.parent.findAll('a',href=re.compile(r'browse.php\?type=categories'))
+                catstext = [cat.string for cat in cats]
+                for cat in catstext:
+                    self.story.addToList('category',cat.string)
+
+            if 'Characters' in label:
+                chars = labelspan.parent.findAll('a',href=re.compile(r'browse.php\?type=characters'))
+                charstext = [char.string for char in chars]
+                for char in charstext:
+                    self.story.addToList('characters',char.string)
+
+            ## Not all sites use Genre, but there's no harm to
+            ## leaving it in.  Check to make sure the type_id number
+            ## is correct, though--it's site specific.
+            if 'Genre' in label:
+                genres = labelspan.parent.findAll('a',href=re.compile(r'browse.php\?type=class&type_id=2')) # XXX
+                genrestext = [genre.string for genre in genres]
+                self.genre = ', '.join(genrestext)
+                for genre in genrestext:
+                    self.story.addToList('genre',genre.string)
+
+            ## Not all sites use Warnings, but there's no harm to
+            ## leaving it in.  Check to make sure the type_id number
+            ## is correct, though--it's site specific.
+            if 'Warnings' in label:
+                warnings = labelspan.parent.findAll('a',href=re.compile(r'browse.php\?type=class&type_id=2')) # XXX
+                warningstext = [warning.string for warning in warnings]
+                self.warning = ', '.join(warningstext)
+                for warning in warningstext:
+                    self.story.addToList('warnings',warning.string)
+
+            if 'Completed' in label:
+                if 'Yes' in value:
+                    self.story.setMetadata('status', 'Completed')
+                else:
+                    self.story.setMetadata('status', 'In-Progress')
+
+            if 'Published' in label:
+                self.story.setMetadata('datePublished', makeDate(stripHTML(value), self.dateformat))
+
+            if 'Updated' in label:
+                # there's a stray [ at the end.
+                #value = value[0:-1]
+                self.story.setMetadata('dateUpdated', makeDate(stripHTML(value), self.dateformat))
+
+        try:
+            # Find Series name from series URL.
+            a = soup.find('a', href=re.compile(r"viewseries.php\?seriesid=\d+"))
+            series_name = a.string
+            series_url = 'http://'+self.host+'/'+a['href']
+
+            # use BeautifulSoup HTML parser to make everything easier to find.
+            seriessoup = self.make_soup(self._fetchUrl(series_url))
+            storyas = seriessoup.findAll('a', href=re.compile(r'^viewstory.php\?sid=\d+$'))
+            i=1
+            for a in storyas:
+                if a['href'] == ('viewstory.php?sid='+self.story.getMetadata('storyId')):
+                    self.setSeries(series_name, i)
+                    self.story.setMetadata('seriesUrl',series_url)
+                    break
+                i+=1
+
+        except:
+            # I find it hard to care if the series parsing fails
+            pass
+
+    # grab the text for an individual chapter.
+    def getChapterText(self, url):
+
+        logger.debug('Getting chapter text from: %s' % url)
+
+        soup = self.make_soup(self._fetchUrl(url))
+
+        div = soup.find('div', {'id' : 'chp_raw'})
+        div.find('div', {'class' : 'wi_authornotes'}).decompose()
+
+        if None == div:
+            raise exceptions.FailedToDownload("Error downloading Chapter: %s!  Missing required element!" % url)
+
+        return self.utf8FromSoup(url,div)

--- a/fanficfare/adapters/adapter_scribblehubcom.py
+++ b/fanficfare/adapters/adapter_scribblehubcom.py
@@ -232,19 +232,11 @@ class ScribbleHubComAdapter(BaseSiteAdapter): # XXX
         # Also, fails when tested with fewer than 2 chapters, which is stumping me - but it has nothing to do with this class I think
         contents_soup = self.make_soup(self._get_contents())
 
-
         for i in range(1, int(contents_soup.find('ol',{'id':'ol_toc'}).get('count')) + 1):
             chapter_url = contents_soup.find('li',{'cnt':str(i)}).find('a').get('href')
             chapter_name = contents_soup.find('li',{'cnt':str(i)}).find('a').get('title')
             logger.debug("Found Chapter " + str(i) + ", name: " + chapter_name + ", url: " + chapter_url)
             self.add_chapter(chapter_name, chapter_url)
-
-        
-
-
-        # for chapter in soup.findAll('a', href=re.compile(r'viewstory.php\?sid='+self.story.getMetadata('storyId')+"&chapter=\d+$")):
-        #     # just in case there's tags, like <i> in chapter titles.
-        #     self.add_chapter(chapter,'http://'+self.host+'/'+chapter['href']+addurl)
 
 
         # eFiction sites don't help us out a lot with their meta data
@@ -263,7 +255,6 @@ class ScribbleHubComAdapter(BaseSiteAdapter): # XXX
         if soup.find('div',{'class': 'wi_fic_desc'}):
             svalue = soup.find('div',{'class': 'wi_fic_desc'})
             self.setDescription(url,svalue)
-            #self.story.setMetadata('description',stripHTML(svalue))
 
         # Categories
         if soup.find('span',{'class': 'wi_fic_showtags_inner'}):

--- a/fanficfare/adapters/adapter_scribblehubcom.py
+++ b/fanficfare/adapters/adapter_scribblehubcom.py
@@ -233,7 +233,7 @@ class ScribbleHubComAdapter(BaseSiteAdapter): # XXX
         contents_soup = self.make_soup(self._get_contents())
 
 
-        for i in range(1, int(contents_soup.find('ol',{'id':'ol_toc'}).get('count'))):
+        for i in range(1, int(contents_soup.find('ol',{'id':'ol_toc'}).get('count')) + 1):
             chapter_url = contents_soup.find('li',{'cnt':str(i)}).find('a').get('href')
             chapter_name = contents_soup.find('li',{'cnt':str(i)}).find('a').get('title')
             logger.debug("Found Chapter " + str(i) + ", name: " + chapter_name + ", url: " + chapter_url)


### PR DESCRIPTION
Tested with the cli on macos + linux with python3.6/7 with about 20 urls, and I think I've thought of everything to catch now!

I couldn't figure out how to run cli.py from without changing the imports, so I left that and just copied the 2 files over to /adapters to test in the fanficfare install directory - /usr/local/lib/python3.7/site-packages/fanficfare/adapters/ and /usr/local/lib/python3.6/dist-packages/fanficfare/adapters - is there an easier way?

Example valid web urls are the story "homepage", like: 
https://www.scribblehub.com/series/123456/
https://www.scribblehub.com/series/123456/story-name/

(123456 isn't actually a story though - here's a real example from their trending page: https://www.scribblehub.com/series/119430/healer/) 

No new libraries have been imported, but I did have to import some of the six.py classes to get the chapters urls - I needed to do a post with a payload which I couldn't get to work with postUrl or fetchUrl in configurable.py without a 400 or an exception. Here's that bit: 

```python
    # Can't use postUrl or fetchUrl in configurable.py. Private method as a quick override
    # Scribblehuib needs an encoded payload I think - all tried:
    # payload = "action=wi_gettocchp&strSID=" + self.story.getMetadata('storyId') + "&strmypostid=0&strFic=yes"
    # payload = {"action": "wi_gettocchp", "strSID": self.story.getMetadata('storyId'), "strmypostid": "0", "strFic": "yes"}
    # payload = {"":"action=wi_gettocchp&strSID=" + self.story.getMetadata('storyId') + "&strmypostid=0&strFic=yes"}
    # data = self._fetchUrlRawOpened("https://www.scribblehub.com/wp-admin/admin-ajax.php", payload)
    def _get_contents(self):
        payload = "action=wi_gettocchp&strSID=" + self.story.getMetadata('storyId') + "&strmypostid=0&strFic=yes"     
        req = Request("https://www.scribblehub.com/wp-admin/admin-ajax.php", data=payload.encode('utf-8'))
    
        ## Specific UA because too many sites are blocking the default python UA.
        opener = build_opener(HTTPCookieProcessor(cl.LWPCookieJar()),GZipProcessor())
        opener.addheaders = [('User-Agent', self.getConfig('user_agent')),
                            ('X-Clacks-Overhead','GNU Terry Pratchett')]

        encoded_data = opener.open(req, None, float(self.getConfig('connect_timeout',30.0))).read()
        data = Configuration._do_reduce_zalgo(self, Configuration._decode(self, encoded_data))

        return data
```

Thanks!



