### PR TITLE
Fix Attribute Error

### DIFF
--- a/fanficfare/adapters/adapter_scribblehubcom.py
+++ b/fanficfare/adapters/adapter_scribblehubcom.py
@@ -295,7 +295,8 @@ class ScribbleHubComAdapter(BaseSiteAdapter): # XXX
             self.story.setMetadata('datePublished', makeDate(stripHTML(soup.find('ol', {'class' : 'toc_ol'}).find('li', {'order' : '1'}).find('span', {'class': 'fic_date_pub'})), self.dateformat))
         except ValueError:
             self.story.setMetadata('datePublished', datetime.date.today())
-
+        except AttributeError:
+            logger.warn("Failed to retrieve date published for " + url)
 
         # Ratings, default to not rated. Scribble hub has no rating system, but has genres for mature and adult, so try to set to these
         self.story.setMetadata('rating', "Not Rated")


### PR DESCRIPTION
Sorry for another one!

A fix for the issue mentioned here: https://www.mobileread.com/forums/showthread.php?p=4013258#post4013258

Sometimes chapters don't start at an index of 1, and could be anything. I think it's probably when authors publish a chapter and then delete and reupload. Only effects `datePublished` so just ignore it. 

Tested on osx python 3.6