### PR TITLE
ScribbleHub - Metadata Fixes

### DIFF
--- a/fanficfare/adapters/adapter_scribblehubcom.py
+++ b/fanficfare/adapters/adapter_scribblehubcom.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2014 Fanficdownloader team, 2018 FanFicFare team
+# Copyright 2014 Fanficdownloader team, 2020 FanFicFare team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -317,6 +317,26 @@ class ScribbleHubComAdapter(BaseSiteAdapter): # XXX
         
         if soup.find("a", {"gid" : "902"}):
             self.story.setMetadata('rating', "Adult")
+
+
+        # Extra metadata from URL + /stats/
+        # Again we know the storyID is valid from before, so this shouldn't raise an exception, and if it does we might want to know about it..
+        data = self._fetchUrl(url + 'stats/')
+        soup = self.make_soup(data)
+        
+        def find_stats_data(element, row, metadata):
+            if element in stripHTML(row.find('th')):
+                self.story.setMetadata(metadata, stripHTML(row.find('td')))
+        
+        if soup.find('table',{'class': 'table_pro_overview'}):
+            stats_table = soup.find('table',{'class': 'table_pro_overview'}).findAll('tr')
+            for row in stats_table:
+                find_stats_data("Total Views (All)", row, "views")
+                find_stats_data("Word Count", row, "numWords")
+                find_stats_data("Average Words", row, "averageWords")
+        else:
+            logger.debug('Failed to get additional metadata [see PR #512] from url: ' + url + "stats/")
+
 
 
     # grab the text for an individual chapter.

--- a/fanficfare/adapters/adapter_scribblehubcom.py
+++ b/fanficfare/adapters/adapter_scribblehubcom.py
@@ -112,32 +112,6 @@ class ScribbleHubComAdapter(BaseSiteAdapter): # XXX
                            rfc2109=False)
         self.get_configuration().get_cookiejar().set_cookie(cookie)
 
-    def performLogin(self, url):
-        params = {}
-
-        if self.password:
-            params['penname'] = self.username
-            params['password'] = self.password
-        else:
-            params['penname'] = self.getConfig("username")
-            params['password'] = self.getConfig("password")
-        params['cookiecheck'] = '1'
-        params['submit'] = 'Submit'
-
-        loginUrl = 'http://' + self.getSiteDomain() + '/user.php?action=login'
-        logger.debug("Will now login to URL (%s) as (%s)" % (loginUrl,
-                                                              params['penname']))
-
-        d = self._fetchUrl(loginUrl, params)
-
-        if "Member Account" not in d : #Member Account
-            logger.info("Failed to login to URL %s as %s" % (loginUrl,
-                                                              params['penname']))
-            raise exceptions.FailedToLogin(url,params['penname'])
-            return False
-        else:
-            return True
-
          ## Getting the chapter list and the meta data, plus 'is adult' checking.
     def extractChapterUrlsAndMetadata(self, get_cover=True):
 
@@ -158,11 +132,6 @@ class ScribbleHubComAdapter(BaseSiteAdapter): # XXX
             else:
                 raise e
 
-        if self.needToLoginCheck(data):
-            # need to log in for this one.
-            self.performLogin(url)
-            data = self._fetchUrl(url)
-            
         # use BeautifulSoup HTML parser to make everything easier to find.
         soup = self.make_soup(data)
 

--- a/fanficfare/adapters/adapter_scribblehubcom.py
+++ b/fanficfare/adapters/adapter_scribblehubcom.py
@@ -144,15 +144,7 @@ class ScribbleHubComAdapter(BaseSiteAdapter): # XXX
         # Set the chapters list cookie to asc
         self.set_contents_cookie()
 
-        if self.is_adult or self.getConfig("is_adult"):
-            # Weirdly, different sites use different warning numbers.
-            # If the title search below fails, there's a good chance
-            # you need a different number.  print data at that point
-            # and see what the 'click here to continue' url says.
-            addurl = "&ageconsent=ok&warning=3"
-        else:
-            addurl=""
-
+        
         # index=1 makes sure we see the story chapter index.  Some
         # sites skip that for one-chapter stories.
         url = self.url
@@ -170,32 +162,7 @@ class ScribbleHubComAdapter(BaseSiteAdapter): # XXX
             # need to log in for this one.
             self.performLogin(url)
             data = self._fetchUrl(url)
-
-        m = re.search(r"'viewstory.php\?sid=\d+((?:&amp;ageconsent=ok)?&amp;warning=\d+)'",data)
-        if m != None:
-            if self.is_adult or self.getConfig("is_adult"):
-                # We tried the default and still got a warning, so
-                # let's pull the warning number from the 'continue'
-                # link and reload data.
-                addurl = m.group(1)
-                # correct stupid &amp; error in url.
-                addurl = addurl.replace("&amp;","&")
-                url = self.url+'&index=1'+addurl
-                logger.debug("URL 2nd try: "+url)
-
-                try:
-                    data = self._fetchUrl(url)
-                except HTTPError as e:
-                    if e.code == 404:
-                        raise exceptions.StoryDoesNotExist(self.url)
-                    else:
-                        raise e
-            else:
-                raise exceptions.AdultCheckRequired(self.url)
-
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
-
+            
         # use BeautifulSoup HTML parser to make everything easier to find.
         soup = self.make_soup(data)
 

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -3068,17 +3068,11 @@ extracharacters:Kurt Hummel,Blaine Anderson
 website_encodings:Windows-1252,utf8
 
 [www.scribblehub.com]
-## Some sites require login (or login for some rated stories) The
-## program can prompt you, or you can save it in config.  In
-## commandline version, this should go in your personal.ini, not
-## defaults.ini.
-#username:YourName
-#password:yourpassword
+extra_valid_entries:views, averageWords
+views_label:Views
+averageWords_label:Average Words (Chapter)
+add_to_titlepage_entries:,views, averageWords
 
-## Some sites also require the user to confirm they are adult for
-## adult content.  In commandline version, this should go in your
-## personal.ini, not defaults.ini.
-#is_adult:true
 
 [www.siye.co.uk]
 ## Site dedicated to these categories/characters/ships


### PR DESCRIPTION
Minor fixes from #512 and added metadata for `numWords`, `views` and `averageWords` (average chapter length). 

Tested on osx python 3.6

Thanks!