### PR TITLE
fiction.live - fix typo preventing download of multi route stories

### DIFF
--- a/fanficfare/adapters/adapter_fictionlive.py
+++ b/fanficfare/adapters/adapter_fictionlive.py
@@ -207,7 +207,7 @@ class FictionLiveAdapter(BaseSiteAdapter):
                     title = r['t']
                 else:
                     title = ""
-                routes.append({{"id": r['_id'], "title": title}})
+                routes.append({"id": r['_id'], "title": title})
 
         # loop setup
         chapter_iter = iter(maintext)


### PR DESCRIPTION
This fixes the typo in my last PR causing #551 and https://github.com/JimmXinu/FanFicFare/issues/547#issuecomment-693245422 .

Tested and working with both stories (both very nsfw) mentioned:
https://fiction.live/stories/Star-Wars-Twilight-of-the-Republic/zZMpSXnx8f7RxJnoa
https://fiction.live/stories/Golden-Empire-Chapter-8-Loyalty/DK5vGtxewbwmKPp7E

Should close #551 