### PR TITLE
Nicely format Scribble Hub's author's notes & news

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -3122,6 +3122,12 @@ views_label:Views
 averageWords_label:Average Words (Chapter)
 add_to_titlepage_entries:,views, averageWords
 
+## Scribble Hub chapters can include author's notes and news blocks.  We've
+## traditionally included them all in the chapter text, but this allows
+## you to customize which you include.  Copy this parameter to your
+## personal.ini and list the ones you don't want.
+#exclude_notes:authornotes,newsboxes
+
 [www.siye.co.uk]
 ## Site dedicated to these categories/characters/ships
 extracategories:Harry Potter

--- a/fanficfare/adapters/adapter_scribblehubcom.py
+++ b/fanficfare/adapters/adapter_scribblehubcom.py
@@ -271,7 +271,7 @@ class ScribbleHubComAdapter(BaseSiteAdapter): # XXX
 
         div = soup.find('div', {'id' : 'chp_raw'})
 
-        exclude_notes=self.getConfigList('exclude_notes')
+        exclude_notes = self.getConfigList('exclude_notes')
 
         if 'authornotes' in exclude_notes:
             # Remove author's notes
@@ -290,9 +290,11 @@ class ScribbleHubComAdapter(BaseSiteAdapter): # XXX
                 new_tag.string = "Author's note:"
                 notes_div.append(new_tag)
 
-                new_tag = soup.new_tag('blockquote')
-                new_tag.append(author_notes.find('div', {'class' : 'wi_authornotes_body'}))
-                notes_div.append(new_tag)
+                author_notes_body = author_notes.find('div', {'class' : 'wi_authornotes_body'})
+                if author_notes_body:
+                    new_tag = soup.new_tag('blockquote')
+                    new_tag.append(author_notes_body)
+                    notes_div.append(new_tag)
 
                 # Clear old children from the note, then add this
                 author_notes.clear()
@@ -311,13 +313,17 @@ class ScribbleHubComAdapter(BaseSiteAdapter): # XXX
                 news['class'] = ['fff_chapter_notes']
                 notes_div = soup.new_tag('div')
 
-                new_tag = soup.new_tag('b')
-                new_tag.string = news.find('div', {'class' : 'wi_news_title'}).get_text()
-                notes_div.append(new_tag)
+                news_title = news.find('div', {'class' : 'wi_news_title'})
+                if news_title:
+                    new_tag = soup.new_tag('b')
+                    new_tag.string = news_title.get_text()
+                    notes_div.append(new_tag)
 
-                new_tag = soup.new_tag('blockquote')
-                new_tag.append(news.find('div', {'class' : 'wi_news_body'}))
-                notes_div.append(new_tag)
+                news_body = news.find('div', {'class' : 'wi_news_body'})
+                if news_body:
+                    new_tag = soup.new_tag('blockquote')
+                    new_tag.append(news_body)
+                    notes_div.append(new_tag)
 
                 # Clear old children from the news box, then add this
                 news.clear()

--- a/fanficfare/adapters/adapter_scribblehubcom.py
+++ b/fanficfare/adapters/adapter_scribblehubcom.py
@@ -275,14 +275,11 @@ class ScribbleHubComAdapter(BaseSiteAdapter): # XXX
 
         if 'authornotes' in exclude_notes:
             # Remove author's notes
-            # There can be multiple in one chapter, so loop until none are left
-            while div.find('div', {'class' : 'wi_authornotes'}):
-                div.find('div', {'class' : 'wi_authornotes'}).decompose()
+            for author_notes in div.find_all('div', {'class' : 'wi_authornotes'}):
+                author_notes.decompose()
         else:
             # Reformat the author's notes
-            # There can be multiple in one chapter, so loop until none are left
-            while div.find('div', {'class' : 'wi_authornotes'}):
-                author_notes = div.find('div', {'class' : 'wi_authornotes'})
+            for author_notes in div.find_all('div', {'class' : 'wi_authornotes'}):
                 author_notes['class'] = ['fff_chapter_notes']
                 notes_div = soup.new_tag('div')
 
@@ -302,14 +299,11 @@ class ScribbleHubComAdapter(BaseSiteAdapter): # XXX
 
         if 'newsboxes' in exclude_notes:
             # Remove author's notes
-            # There can be multiple in one chapter, so loop until none are left
-            while div.find('div', {'class' : 'wi_news'}):
-                div.find('div', {'class' : 'wi_news'}).decompose()
+            for news in div.find('div', {'class' : 'wi_news'}):
+                news.decompose()
         else:
             # Reformat the news boxes
-            # There can be multiple in one chapter, so loop until none are left
-            while div.find('div', {'class' : 'wi_news'}):
-                news = div.find('div', {'class' : 'wi_news'})
+            for news in div.find_all('div', {'class' : 'wi_news'}):
                 news['class'] = ['fff_chapter_notes']
                 notes_div = soup.new_tag('div')
 

--- a/fanficfare/adapters/adapter_scribblehubcom.py
+++ b/fanficfare/adapters/adapter_scribblehubcom.py
@@ -271,6 +271,8 @@ class ScribbleHubComAdapter(BaseSiteAdapter): # XXX
 
         div = soup.find('div', {'id' : 'chp_raw'})
 
+        exclude_notes=self.getConfigList('exclude_notes')
+
         if 'authornotes' in exclude_notes:
             # Remove author's notes
             # There can be multiple in one chapter, so loop until none are left

--- a/fanficfare/adapters/adapter_scribblehubcom.py
+++ b/fanficfare/adapters/adapter_scribblehubcom.py
@@ -271,43 +271,55 @@ class ScribbleHubComAdapter(BaseSiteAdapter): # XXX
 
         div = soup.find('div', {'id' : 'chp_raw'})
 
-        # Reformat the author's notes
-        # There can be multiple in one chapter, so loop until none are left
-        while div.find('div', {'class' : 'wi_authornotes'}):
-            author_notes = div.find('div', {'class' : 'wi_authornotes'})
-            author_notes['class'] = ['fff_chapter_notes']
-            notes_div = soup.new_tag('div')
+        if 'authornotes' in exclude_notes:
+            # Remove author's notes
+            # There can be multiple in one chapter, so loop until none are left
+            while div.find('div', {'class' : 'wi_authornotes'}):
+                div.find('div', {'class' : 'wi_authornotes'}).decompose()
+        else:
+            # Reformat the author's notes
+            # There can be multiple in one chapter, so loop until none are left
+            while div.find('div', {'class' : 'wi_authornotes'}):
+                author_notes = div.find('div', {'class' : 'wi_authornotes'})
+                author_notes['class'] = ['fff_chapter_notes']
+                notes_div = soup.new_tag('div')
 
-            new_tag = soup.new_tag('b')
-            new_tag.string = "Author's note:"
-            notes_div.append(new_tag)
+                new_tag = soup.new_tag('b')
+                new_tag.string = "Author's note:"
+                notes_div.append(new_tag)
 
-            new_tag = soup.new_tag('blockquote')
-            new_tag.append(author_notes.find('div', {'class' : 'wi_authornotes_body'}))
-            notes_div.append(new_tag)
+                new_tag = soup.new_tag('blockquote')
+                new_tag.append(author_notes.find('div', {'class' : 'wi_authornotes_body'}))
+                notes_div.append(new_tag)
 
-            # Clear old children from the note, then add this
-            author_notes.clear()
-            author_notes.append(notes_div)
+                # Clear old children from the note, then add this
+                author_notes.clear()
+                author_notes.append(notes_div)
 
-        # Reformat the news boxes
-        # There can be multiple in one chapter, so loop until none are left
-        while div.find('div', {'class' : 'wi_news'}):
-            news = div.find('div', {'class' : 'wi_news'})
-            news['class'] = ['fff_chapter_notes']
-            notes_div = soup.new_tag('div')
+        if 'newsboxes' in exclude_notes:
+            # Remove author's notes
+            # There can be multiple in one chapter, so loop until none are left
+            while div.find('div', {'class' : 'wi_news'}):
+                div.find('div', {'class' : 'wi_news'}).decompose()
+        else:
+            # Reformat the news boxes
+            # There can be multiple in one chapter, so loop until none are left
+            while div.find('div', {'class' : 'wi_news'}):
+                news = div.find('div', {'class' : 'wi_news'})
+                news['class'] = ['fff_chapter_notes']
+                notes_div = soup.new_tag('div')
 
-            new_tag = soup.new_tag('b')
-            new_tag.string = news.find('div', {'class' : 'wi_news_title'}).get_text()
-            notes_div.append(new_tag)
+                new_tag = soup.new_tag('b')
+                new_tag.string = news.find('div', {'class' : 'wi_news_title'}).get_text()
+                notes_div.append(new_tag)
 
-            new_tag = soup.new_tag('blockquote')
-            new_tag.append(news.find('div', {'class' : 'wi_news_body'}))
-            notes_div.append(new_tag)
+                new_tag = soup.new_tag('blockquote')
+                new_tag.append(news.find('div', {'class' : 'wi_news_body'}))
+                notes_div.append(new_tag)
 
-            # Clear old children from the news box, then add this
-            news.clear()
-            news.append(notes_div)
+                # Clear old children from the news box, then add this
+                news.clear()
+                news.append(notes_div)
 
         if None == div:
             raise exceptions.FailedToDownload("Error downloading Chapter: %s!  Missing required element!" % url)

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -3144,6 +3144,12 @@ views_label:Views
 averageWords_label:Average Words (Chapter)
 add_to_titlepage_entries:,views, averageWords
 
+## Scribble Hub chapters can include author's notes and news blocks.  We've
+## traditionally included them all in the chapter text, but this allows
+## you to customize which you include.  Copy this parameter to your
+## personal.ini and list the ones you don't want.
+#exclude_notes:authornotes,newsboxes
+
 [www.siye.co.uk]
 ## Site dedicated to these categories/characters/ships
 extracategories:Harry Potter


### PR DESCRIPTION
This makes it so that instead of removing authors notes and leaving news boxes alone from Scribble Hub it instead formats them basically the same as AO3's chapter notes, with a bold title and then in a block quote. I also have it putting them in a `fff_chapter_notes` div, the same as AO3, so that custom CSS on that should work the same I think.

I tested with [The Walls of Anamoor](https://www.scribblehub.com/series/161834/the-walls-of-anamoor/) chapter 1 and [A Transformative Spark](https://www.scribblehub.com/series/161220/a-transformative-spark/) chapter 1 as they have two of news boxes and author's notes respectively.

<details><summary>Examples</summary>

![スクリーンショット 2020-10-02 10 47 50](https://user-images.githubusercontent.com/41608708/94943077-cddaa600-049c-11eb-8523-bfc54cc3c8f8.png)
![スクリーンショット 2020-10-02 10 48 03](https://user-images.githubusercontent.com/41608708/94943086-cfa46980-049c-11eb-9788-d12465cb1ea0.png)

</details>

---

Please let me know if you'd like me to change anything or so, I tried to stick to the code style of the file but I don't work with Python or this plugin stuff too much so I may have done something badly 😅 