### PR TITLE
Pass None to bs4.find() instead of empty string

### DIFF
--- a/fanficfare/adapters/adapter_royalroadcom.py
+++ b/fanficfare/adapters/adapter_royalroadcom.py
@@ -173,7 +173,7 @@ class RoyalRoadAdapter(BaseSiteAdapter):
         self.story.setMetadata('title',title)
 
         # Find authorid and URL from... author url.
-        mt_card_social = soup.find('',{'class':'mt-card-social'})
+        mt_card_social = soup.find(None,{'class':'mt-card-social'})
         author_link = mt_card_social('a')[-1]
         if author_link:
             authorId = author_link['href'].rsplit('/', 1)[1]
@@ -228,7 +228,7 @@ class RoyalRoadAdapter(BaseSiteAdapter):
                 self.story.addToList('warnings',stripHTML(li))
 
         # get cover
-        img = soup.find('',{'class':'row fic-header'}).find('img')
+        img = soup.find(None,{'class':'row fic-header'}).find('img')
         if img:
             cover_url = img['src']
             self.setCoverImage(url,cover_url)


### PR DESCRIPTION
BeatifulSoup apparently treats an empty string like any other string, i.e. as a search filter for tag names. Passing None seems to disable this filtering. Couldn't find the relevant docs for this, so any representation of find()'s behaviour here is based on my testing only. (on BeatifulSoup 4.9.3)

A quick code search on the repo shows this is the only place find gets explicitly passed an empty string. Indeed, all other usages seem to list the tag to expect (in this case, both are <div>s), but I chose to follow this adapter's choice of not filtering.

Closes #565 (tested on the url mentioned there, it works)