### PR TITLE
fiction.live - handle api returning non-int values for votes

### DIFF
--- a/fanficfare/adapters/adapter_fictionlive.py
+++ b/fanficfare/adapters/adapter_fictionlive.py
@@ -386,6 +386,10 @@ class FictionLiveAdapter(BaseSiteAdapter):
                 if 'multiple' in chunk and chunk['multiple'] == False:
                     vote = [vote] # normalize to list
                 for v in vote:
+                    # v should only be int, but there is at least one story where some unrelated string was returned,
+                    #   so let's just ignore non-int values here
+                    if not isinstance(v, int):
+                        continue
                     if 0 <= v <= len(choices):
                         output[v] += 1
             return output


### PR DESCRIPTION
In this story: https://fiction.live/stories/Star-Wars-Twilight-of-the-Republic/zZMpSXnx8f7RxJnoa/Chapter-9-Calm-Before-the-Storm/pFZu4rvwQjocoi3Kj the api returns a vote that is not an int, but this unrelated string instead: 'onbashira :V'. Search for 'keep name' to find the choice where it appears. The vote shows up as 'undefined' in the choices list.

That vote value is not valid and not supposed to be there, so let's just ignore non-int values for votes, should they appear.

I already successfully tested downloading this quest before without any problems, so I'm not sure why I only came across this error now.