### PR TITLE
Add mappings to formats of a few strings

### DIFF
--- a/calibre-plugin/fff_plugin.py
+++ b/calibre-plugin/fff_plugin.py
@@ -1352,7 +1352,7 @@ class FanFicFarePlugin(InterfaceAction):
                                                   <p>%s</p>
                                                   <p>%s</p>'''%(
                                 _('Change Story URL?'),
-                                _('<b>%s</b> by <b>%s</b> is already in your library with a different source URL:')%(mi.title,', '.join(mi.author)),
+                                _('<b>%(title)s</b> by <b>%(author)s</b> is already in your library with a different source URL:')%{'title':mi.title,'author':', '.join(mi.author)},
                                 _('In library: <a href="%(liburl)s">%(liburl)s</a>')%{'liburl':liburl},
                                 _('New URL: <a href="%(newurl)s">%(newurl)s</a>')%{'newurl':book['url']},
                                 _("Click '<b>Yes</b>' to update/overwrite book with new URL."),
@@ -1366,7 +1366,7 @@ class FanFicFarePlugin(InterfaceAction):
                                                   <p>%s</p>
                                                   <p>%s</p>'''%(
                                     _('Download as New Book?'),
-                                    _('<b>%s</b> by <b>%s</b> is already in your library with a different source URL.')%(mi.title,', '.join(mi.author)),
+                                    _('<b>%(title)s</b> by <b>%(author)s</b> is already in your library with a different source URL.')%{'title':mi.title,'author':', '.join(mi.author)},
                                     _('You chose not to update the existing book.  Do you want to add a new book for this URL?'),
                                     _('New URL: <a href="%(newurl)s">%(newurl)s</a>')%{'newurl':book['url']},
                                     _("Click '<b>Yes</b>' to a new book with new URL."),
@@ -2700,7 +2700,7 @@ class FanFicFarePlugin(InterfaceAction):
         book['comments'] = '<div>'+d+'<p>' +_("Anthology containing:")+"</p>\n\n"
         wraptitle = lambda x : '<p><b>'+x+'</b></p>\n'
         if len(book['author']) > 1:
-            mkbooktitle = lambda x : wraptitle(_("%s by %s") % (x['title'],' & '.join(x['author'])))
+            mkbooktitle = lambda x : wraptitle(_("%(title)s by %(author)s") % {'title':x['title'],'author':' & '.join(x['author'])})
         else:
             mkbooktitle = lambda x : wraptitle(x['title'])
 

--- a/calibre-plugin/jobs.py
+++ b/calibre-plugin/jobs.py
@@ -298,7 +298,7 @@ def do_download_for_worker(book,options,merge,notification=lambda x,y:x):
                 writer.writeStory(outfilename=outfile, forceOverwrite=True)
 
                 book['comment'] = _('Update %(fileform)s completed, added %(added)s chapters for %(total)s total.')%\
-                    {'fileform':options['fileform'],'added':(urlchaptercount-chaptercount),'total':urlchaptercount)
+                    {'fileform':options['fileform'],'added':(urlchaptercount-chaptercount),'total':urlchaptercount}
                 book['all_metadata'] = story.getAllMetadata(removeallentities=True)
                 if options['savemetacol'] != '':
                     book['savemetacol'] = story.dump_html_metadata()

--- a/calibre-plugin/jobs.py
+++ b/calibre-plugin/jobs.py
@@ -90,7 +90,7 @@ def do_download_worker(book_list,
         book_list.append(job.result)
         book_id = job._book['calibre_id']
         count = count + 1
-        notification(float(count)/total, _('%d of %d stories finished downloading')%(count,total))
+        notification(float(count)/total, _('%(count)d of %(total)d stories finished downloading')%{'count':count,'total':total})
         # Add this job's output to the current log
         logger.info('Logfile for book ID %s (%s)'%(book_id, job._book['title']))
         logger.info(job.details)
@@ -297,8 +297,8 @@ def do_download_for_worker(book,options,merge,notification=lambda x,y:x):
                 inject_cal_cols(book,story,configuration)
                 writer.writeStory(outfilename=outfile, forceOverwrite=True)
 
-                book['comment'] = _('Update %s completed, added %s chapters for %s total.')%\
-                    (options['fileform'],(urlchaptercount-chaptercount),urlchaptercount)
+                book['comment'] = _('Update %(fileform)s completed, added %(added)s chapters for %(total)s total.')%\
+                    {'fileform':options['fileform'],'added':(urlchaptercount-chaptercount),'total':urlchaptercount)
                 book['all_metadata'] = story.getAllMetadata(removeallentities=True)
                 if options['savemetacol'] != '':
                     book['savemetacol'] = story.dump_html_metadata()


### PR DESCRIPTION
I was translating to Japanese and came across a couple strings that would be better translated with the variables in a different order, but as these are using the classic style of string formatting without mappings I couldn't change it, so I added mappings to the variables.

An example:
`Title by Author is already in your library with a different source URL:`
should be like this in Japanese:
`AuthorによるTitleはすでに別なソースURLでライブラリにある:`