### PR TITLE
Fiction.live fixes -- URL normalization, .ini changes, and a fix to story updates not being recognised

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -1686,6 +1686,7 @@ website_encodings:Windows-1252,utf8
 ## however, stories containing many images can be *very* slow to download, and create large files.
 #include_images:true
 #no_image_processing:true
+#dedup_img_files:false
 
 ## fiction.live spoilers display as a (blank) block until clicked, then they can become inline text.
 ## with true, adds them to an outlined block marked as a spoiler.
@@ -1703,6 +1704,7 @@ extratags:
 
 extra_valid_entries:key_tags, tags, likes, live, reader_input
 extra_titlepage_entries:key_tags, tags, likes, live, reader_input
+extra_subject_tags:tags, key_tags
 key_tags_label:Key Tags
 tags_label:Tags
 live_label:Next Live Session

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -1717,6 +1717,7 @@ website_encodings:Windows-1252,utf8
 ## however, stories containing many images can be *very* slow to download, and create large files.
 #include_images:true
 #no_image_processing:true
+#dedup_img_files:true
 
 ## fiction.live spoilers display as a (blank) block until clicked, then they can become inline text.
 ## with true, adds them to an outlined block marked as a spoiler.
@@ -1734,6 +1735,7 @@ extratags:
 
 extra_valid_entries:key_tags, tags, likes, live, reader_input
 extra_titlepage_entries:key_tags, tags, likes, live, reader_input
+extra_subject_tags:tags, key_tags
 key_tags_label:Key Tags
 tags_label:Tags
 live_label:Next Live Session


### PR DESCRIPTION
Various fixes and improvements for the fiction.live adapter. 

In particular:
* tags/key tags should now show up in Calibre
* URLs are now normalized and should be recognised even if they're formatted differently in different sources (like email story-update notifications vs everything else, for example)
* The most-recent chapter now includes the update-time of the most recent chunk in the URL (rather than MAX_INT for the end timestamp). This should mean that if a story publishes new content, it's chapter metadata will change and fanficfare will notice the update and re-download that chapter. 