### PR TITLE
Royalroad

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -3285,6 +3285,13 @@ extratags:
 ## chapter text.
 #include_author_notes:true
 
+## default formatting for author's notes and tables in the story text
+## makes some stories drastically easier to visually parse
+add_to_output_css:
+ td {  padding: 4pt }
+ table { border: 1px solid black; border-collapse: collapse; }
+ .author-note-portlet { border: 1px solid black; border-collapse: collapse; padding: 4pt }
+
 [www.scarvesandcoffee.net]
 ## Some sites do not require a login, but do require the user to
 ## confirm they are adult for adult content.  In commandline version,

--- a/fanficfare/adapters/adapter_royalroadcom.py
+++ b/fanficfare/adapters/adapter_royalroadcom.py
@@ -248,6 +248,7 @@ class RoyalRoadAdapter(BaseSiteAdapter):
         div = soup.find('div',{'class':"chapter-inner chapter-content"})
 
         # TODO: these stories often have tables in, but these wont render correctly
+        # defaults.ini output CSS now outlines/pads the tables, at least. 
 
         if None == div:
             raise exceptions.FailedToDownload("Error downloading Chapter: %s!  Missing required element!" % url)

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -3307,6 +3307,13 @@ extratags:
 ## chapter text.
 #include_author_notes:true
 
+## default formatting for author's notes and tables in the story text
+## makes some stories drastically easier to visually parse
+add_to_output_css:
+ td {  padding: 4pt }
+ table { border: 1px solid black; border-collapse: collapse; }
+ .author-note-portlet { border: 1px solid black; border-collapse: collapse; padding: 4pt }
+
 [www.scarvesandcoffee.net]
 ## Some sites do not require a login, but do require the user to
 ## confirm they are adult for adult content.  In commandline version,


### PR DESCRIPTION
 add default CSS formatting for author's notes and for in-story tables/statblocks

IMO, this makes quite a few royalroad stories go from visually confusing and hard to parse to readable. I think this makes for much better defaults for a new install.

 LitRPG/gamelit stories in particular use a lot of tables, sometimes as pop-up 'blue boxes' mixed in with the text, other times in additonal 'statblocks' full of numbers and other info. It's probably impossible to do anything that'll format *all* of these well, but at the very least giving an outline separating them from the rest of the text and some padding within the tables helps the visual experience and drastically, while not overspecializing to specific stories.

Likewise, for stories that begin chapters with author's notes, showing where the note ends and the chapter text begins makes chapters less confusing. 