### PR TITLE
CSS fixes for royalroad (formatting) and fictionlive (no pt units)

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -3285,6 +3285,13 @@ extratags:
 ## chapter text.
 #include_author_notes:true
 
+## default formatting for author's notes and tables in the story text
+## makes some stories drastically easier to visually parse
+add_to_output_css:
+ td {  padding: 4pt }
+ table { border: 1px solid black; border-collapse: collapse; }
+ .author-note-portlet { border: 1px solid black; border-collapse: collapse; padding: 4pt }
+
 [www.scarvesandcoffee.net]
 ## Some sites do not require a login, but do require the user to
 ## confirm they are adult for adult content.  In commandline version,

--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -1738,15 +1738,15 @@ keep_in_order_key_tags:true
 
 add_to_output_css:
  table.voteblock { border-collapse: collapse; }
- td { padding: 6pt; }
+ td { padding: 0.5em; }
  td.votecount { text-align: right; }
  .dice {
     border-left: 1px solid;
-    padding-left: 4pt;
+    padding-left: 0.25em;
  }
  .choiceitem {
     border-bottom: 1px solid gray;
-    padding: 6pt;
+    padding: 0.5em;
  }
  div.ut {
     font-size: xx-small;
@@ -3288,9 +3288,9 @@ extratags:
 ## default formatting for author's notes and tables in the story text
 ## makes some stories drastically easier to visually parse
 add_to_output_css:
- td {  padding: 4pt }
- table { border: 1px solid black; border-collapse: collapse; }
- .author-note-portlet { border: 1px solid black; border-collapse: collapse; padding: 4pt }
+ td {  padding: 0.5em }
+ table { border: 1px solid; border-collapse: collapse; }
+ .author-note-portlet { border: 1px solid; border-collapse: collapse; padding: 0.5em }
 
 [www.scarvesandcoffee.net]
 ## Some sites do not require a login, but do require the user to

--- a/fanficfare/adapters/adapter_royalroadcom.py
+++ b/fanficfare/adapters/adapter_royalroadcom.py
@@ -247,6 +247,7 @@ class RoyalRoadAdapter(BaseSiteAdapter):
         div = soup.find('div',{'class':"chapter-inner chapter-content"})
 
         # TODO: these stories often have tables in, but these wont render correctly
+        # defaults.ini output CSS now outlines/pads the tables, at least. 
 
         if None == div:
             raise exceptions.FailedToDownload("Error downloading Chapter: %s!  Missing required element!" % url)

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -1769,15 +1769,15 @@ keep_in_order_key_tags:true
 
 add_to_output_css:
  table.voteblock { border-collapse: collapse; }
- td { padding: 6pt; }
+ td { padding: 0.5em; }
  td.votecount { text-align: right; }
  .dice {
     border-left: 1px solid;
-    padding-left: 4pt;
+    padding-left: 0.25em;
  }
  .choiceitem {
     border-bottom: 1px solid gray;
-    padding: 6pt;
+    padding: 0.5em;
  }
  div.ut {
     font-size: xx-small;
@@ -3310,9 +3310,9 @@ extratags:
 ## default formatting for author's notes and tables in the story text
 ## makes some stories drastically easier to visually parse
 add_to_output_css:
- td {  padding: 4pt }
- table { border: 1px solid black; border-collapse: collapse; }
- .author-note-portlet { border: 1px solid black; border-collapse: collapse; padding: 4pt }
+ td {  padding: 0.5em }
+ table { border: 1px solid; border-collapse: collapse; }
+ .author-note-portlet { border: 1px solid; border-collapse: collapse; padding: 0.5em }
 
 [www.scarvesandcoffee.net]
 ## Some sites do not require a login, but do require the user to

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -3307,6 +3307,13 @@ extratags:
 ## chapter text.
 #include_author_notes:true
 
+## default formatting for author's notes and tables in the story text
+## makes some stories drastically easier to visually parse
+add_to_output_css:
+ td {  padding: 4pt }
+ table { border: 1px solid black; border-collapse: collapse; }
+ .author-note-portlet { border: 1px solid black; border-collapse: collapse; padding: 4pt }
+
 [www.scarvesandcoffee.net]
 ## Some sites do not require a login, but do require the user to
 ## confirm they are adult for adult content.  In commandline version,


### PR DESCRIPTION
Sorry about the lost pull request, I got myself into git trouble, and this seemed like the best way out. 

I've redone all the CSS to be in em units not pt units (with the exception of 1px borders). 