### PR TITLE
map normalized URL to keys used by browser cache

### DIFF
--- a/fanficfare/adapters/base_adapter.py
+++ b/fanficfare/adapters/base_adapter.py
@@ -713,6 +713,13 @@ class BaseSiteAdapter(Configurable):
     def normalize_chapterurl(self,url):
         return url
 
+    def extract_normalized_url(self, contains_url):
+        """Extract and normalize a valid URL for the adapter's site from a string that could contain other things"""
+        match = re.search(self.getSiteURLPattern(), contains_url)
+        if match:
+            return self.normalize_chapterurl(match.group())
+        return None
+
 def cachedfetch(realfetch,cache,url,referer=None):
     if url in cache:
         return cache[url]

--- a/fanficfare/browsercache/basebrowsercache.py
+++ b/fanficfare/browsercache/basebrowsercache.py
@@ -32,6 +32,10 @@ class BaseBrowserCache:
                 return None
         return None
 
+    def get_keys(self):
+        """ Return all keys for existing entries in underlying cache as set of strings"""
+        return None  # must be overridden
+
     def get_data(self, url):
         """ Return decoded data for specified key (a URL string) or None """
         return None  # must be overridden

--- a/fanficfare/browsercache/chromediskcache.py
+++ b/fanficfare/browsercache/chromediskcache.py
@@ -42,6 +42,10 @@ class ChromeDiskCache(BaseBrowserCache):
                 return False
         return True
 
+    def get_keys(self):
+        """ Return all keys for existing entries in underlying cache as set of strings"""
+        return self.chromagnon_cache.cache_keys
+
     def get_data(self, url):
         """ Return decoded data for specified key (a URL string) or None """
         return self.chromagnon_cache.get_cached_file(url)


### PR DESCRIPTION
### Changes in PR

Removed the need for using `urltitle` in `fanfiction.net` adapter, and to have any hardcoded reference to `"fanfiction.net"` in the code to read from browser disk cache, by implementing the following:

Added a class method `BaseBrowserCache.get_keys` that extracts all of the keys in the cache files as a set of strings.

Added an argument to the  `BrowserCache __init__` function to pass it the adapter instance that is calling it. In the `__init__` it calls a new class method `BaseSiteAdapter.extract_normalized_url()` to construct a dictionary from the set of keys in the cache mapping the adapter's normalized URL as key to the cache's actual key.

Removed all of the code that was added for `urltitle` from the `fanfictionnet` adapter. Now when `BrowserCache.get_data(url)` is called with a normalized URL for the adapter, it uses that as a key to look up in the dictionary it made in `__init__` and finds the actual key that the cache has for that URL.

This does mean that all calls from the adapter to `self.browser_cache.get_data(url)` have to pass a normalized URL. This also takes care of any problems with query strings in URLs because calling `get_data` with the normalized URL will always end up mapping to whatever was used to store the page in the cache.

This makes it transparent whether or not the browser has done that new stuff of adding `_dk_` etc., parts to the strings used as keys in the cache, and allows the normalized URL to not have to match to some canonical form that the web site uses that are the only pages that the browser has cached.

Other related changes:

Took care whether some functions using URLs or keys for the cache are specified as taking or returning strings or byte-strings, so that encoding and decoding can be done only when required, and there won't be surprises from  mismatched types.

Replaced some for loops I had written with simpler and more readable code using map or set or dict comprehensions.

Added `'deflate'` compression, which uses `zlib`, to the `chromagnon` code, like it already was in `SimpleCache`.

In `SimpleCache._validate_entry_file(path)` return `None` instead of raise an exception if path is not a valid cache entry file, to allow the function to be used to test if a file is valid rather than treat it as an error if it isn't.

 
