### PR TITLE
minor changes to track fictionlive website updates

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -1832,17 +1832,15 @@ show_timestamps:false
 ## site has more original than fan fiction
 extratags:
 
-extra_valid_entries:key_tags, tags, likes, live, reader_input
-extra_titlepage_entries:key_tags, tags, likes, live, reader_input
-extra_subject_tags:tags, key_tags
-key_tags_label:Key Tags
+extra_valid_entries:tags, likes, live, reader_input
+extra_titlepage_entries:tags, likes, live, reader_input
+extra_subject_tags:tags
 tags_label:Tags
 live_label:Next Live Session
 live_format:%%Y-%%m-%%d at %%H:%%M %%p
 likes_label:Likes
 reader_input_label:Reader Input
 keep_in_order_tags:true
-keep_in_order_key_tags:true
 
 add_to_output_css:
  table.voteblock { border-collapse: collapse; }

--- a/fanficfare/adapters/adapter_fictionlive.py
+++ b/fanficfare/adapters/adapter_fictionlive.py
@@ -437,9 +437,11 @@ class FictionLiveAdapter(BaseSiteAdapter):
 
         num_voters = len(chunk['votes']) if 'votes' in chunk else 0
 
+        vote_title = chunk['b'] if 'b' in chunk else "Choices"
+        
         output = ""
         # start with the header
-        output += u"<h4><span>Choices — <small>Voting " + closed
+        output += u"<h4><span>" + vote_title + " — <small>Voting " + closed
         output += u" — " + str(num_voters) + " voters</small></span></h4>\n"
 
         # we've got everything needed to build the html for our vote table.

--- a/fanficfare/adapters/adapter_fictionlive.py
+++ b/fanficfare/adapters/adapter_fictionlive.py
@@ -156,9 +156,7 @@ class FictionLiveAdapter(BaseSiteAdapter):
 
         show_spoiler_tags = self.getConfig('show_spoiler_tags')
         spoiler_tags = data['spoilerTags'] if 'spoilerTags' in data else []
-        for tag in tags[:5]:
-            self.story.addToList('key_tags', tag)
-        for tag in tags[5:]:
+        for tag in tags:
             if show_spoiler_tags or not tag in spoiler_tags:
                 self.story.addToList('tags', tag)
 

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -1854,17 +1854,15 @@ show_timestamps:false
 ## site has more original than fan fiction
 extratags:
 
-extra_valid_entries:key_tags, tags, likes, live, reader_input
-extra_titlepage_entries:key_tags, tags, likes, live, reader_input
-extra_subject_tags:tags, key_tags
-key_tags_label:Key Tags
+extra_valid_entries:tags, likes, live, reader_input
+extra_titlepage_entries:tags, likes, live, reader_input
+extra_subject_tags:tags
 tags_label:Tags
 live_label:Next Live Session
 live_format:%%Y-%%m-%%d at %%H:%%M %%p
 likes_label:Likes
 reader_input_label:Reader Input
 keep_in_order_tags:true
-keep_in_order_key_tags:true
 
 add_to_output_css:
  table.voteblock { border-collapse: collapse; }


### PR DESCRIPTION
Two small tweaks to the adapter, to track website changes.

Fictionlive is no longer pulling out and highlighting the start of the tag list as it's own special thing in the UI, after a year or two of experimenting with the position and number of highlighted tags. 
This removes metadata (or rather, doesn't write it anymore) -- is this ok with people's existing books?

Also, apparently you can do vote titles now, and I've seen a story use them. It's easy to support, thankfully. 
