### PR TITLE
Use newer Calibre image processing, add JPG quality setting

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -1049,6 +1049,10 @@ output_css:
 ## include_images is *only* available in epub and html output format.
 include_images:true
 
+## Quality level to use when converting images to jpg. Range is 0-100,
+## reasonable values likely to be in the range 70-95.
+jpg_quality: 95
+
 ## If set, the first image found will be made the cover image.  If
 ## keep_summary_html is true, any images in summary will be before any
 ## in chapters.
@@ -1157,6 +1161,10 @@ nook_img_fix:true
 ## include_images is *only* available in epub and html output formats.
 ## include_images is *not* available in the web service in any format.
 #include_images:false
+
+## Quality level to use when converting images to jpg. Range is 0-100,
+## reasonable values likely to be in the range 70-95.
+#jpg_quality: 95
 
 ## When include_images:true, you can also specify a list of images to
 ## include in the EPUB or HTML, such as for use in customized CSS.

--- a/calibre-plugin/plugin-example.ini
+++ b/calibre-plugin/plugin-example.ini
@@ -43,6 +43,10 @@
 ## download as epub and use Calibre to convert.
 #include_images:true
 
+## Quality level to use when converting images to jpg. Range is 0-100,
+## reasonable values likely to be in the range 70-95.
+#jpg_quality: 95
+
 ## If not set, the summary will have all html stripped for safety.
 ## Both this and include_images must be true to get images in the
 ## summary.

--- a/fanficfare/configurable.py
+++ b/fanficfare/configurable.py
@@ -255,6 +255,7 @@ def get_valid_set_options():
                'windows_eol':(None,['txt'],boollist),
 
                'include_images':(None,['epub','html'],boollist),
+               'jpg_quality':(None,['epub','html'],None),
                'additional_images':(None,['epub','html'],None),
                'grayscale_images':(None,['epub','html'],boollist),
                'no_image_processing':(None,['epub','html'],boollist),
@@ -398,6 +399,7 @@ def get_valid_keywords():
                  'grayscale_images',
                  'image_max_size',
                  'include_images',
+                 'jpg_quality',
                  'additional_images',
                  'include_logpage',
                  'logpage_at_end',

--- a/fanficfare/example.ini
+++ b/fanficfare/example.ini
@@ -24,6 +24,10 @@
 ## download as epub and use Calibre to convert.  true by default in plugin.
 #include_images:true
 
+## Quality level to use when converting images to jpg. Range is 0-100,
+## reasonable values likely to be in the range 70-95.
+#jpg_quality: 95
+
 ## If not set, the summary will have all html stripped for safety.
 ## Both this and include_images must be true to get images in the
 ## summary.


### PR DESCRIPTION
This changes Calibre image processing to use the newer Qt-based methods rather than the old ImageMagick compat wrapper methods. The reason I did this is to add support for setting the quality of JPEG files being converted. The legacy `export` method always uses quality 95, which is very high. I've found that q85 significantly reduces sizes of grayscale images without any noticeable quality change, at least to my eyes. 95 is kept as the default in case this isn't globally true.

I originally tried always using Pillow but found that it was unable to load WebPs, claiming that WebP support wasn't installed. I'm pretty sure Calibre does in fact install it, and my local version of Pillow can load them, so I don't know why that was happening. I did update the Pillow based saving to tell the encoder to use the preferred quality and optimize the JPG (very small size saving). For users who are using Pillow, not Calibre (I think CLI users?) this is a behavior change as [the default quality there is 75](https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#jpeg).

I've likely done *something* wrong in this code; this is the most Python I've ever written. That said, it does appear to work on fics I've downloaded, giving me all the images I'd expect, no errors in the log, and my Kindle can handle the (Calibre-converted) AZW3 just fine.