### PR TITLE
makeplugin: add option to build plugin intended as a system plugin

### DIFF
--- a/calibre-plugin/__init__.py
+++ b/calibre-plugin/__init__.py
@@ -115,9 +115,13 @@ class FanFicFareBase(InterfaceActionBase):
             # I believe there's no performance hit loading these here when
             # CLI--it would load everytime anyway.
             from calibre.library import db
-            from calibre_plugins.fanficfare_plugin.fanficfare.cli import main as fff_main
             from calibre_plugins.fanficfare_plugin.prefs import PrefsFacade
-            from calibre_plugins.fanficfare_plugin.fanficfare.six import ensure_text
+            try:
+                from calibre_plugins.fanficfare_plugin.fanficfare.cli import main as fff_main
+                from calibre_plugins.fanficfare_plugin.fanficfare.six import ensure_text
+            except:
+                from fanficfare.cli import main as fff_main
+                from fanficfare.six import ensure_text
             from optparse import OptionParser
 
             parser = OptionParser('%prog --run-plugin '+self.name+' -- [options] <storyurl>')

--- a/calibre-plugin/basicinihighlighter.py
+++ b/calibre-plugin/basicinihighlighter.py
@@ -13,8 +13,10 @@ try:
     from PyQt5.Qt import (Qt, QSyntaxHighlighter, QTextCharFormat, QBrush)
 except ImportError as e:
     from PyQt4.Qt import (Qt, QSyntaxHighlighter, QTextCharFormat, QBrush)
-
-from .fanficfare.six import string_types
+try:
+    from .fanficfare.six import string_types
+except:
+    from fanficfare.six import string_types
 
 class BasicIniHighlighter(QSyntaxHighlighter):
     '''

--- a/calibre-plugin/common_utils.py
+++ b/calibre-plugin/common_utils.py
@@ -29,7 +29,10 @@ from calibre.gui2.actions import menu_action_unique_name
 from calibre.gui2.keyboard import ShortcutConfig
 from calibre.utils.config import config_dir
 from calibre.utils.date import now, format_date, qt_to_dt, UNDEFINED_DATE
-from .fanficfare.six import text_type as unicode
+try:
+    from .fanficfare.six import text_type as unicode
+except:
+    from fanficfare.six import text_type as unicode
 
 # Global definition of our plugin name. Used for common functions that require this.
 plugin_name = None

--- a/calibre-plugin/config.py
+++ b/calibre-plugin/config.py
@@ -45,7 +45,10 @@ else:
 
 from calibre.gui2 import dynamic, info_dialog
 from calibre.gui2.complete2 import EditWithComplete
-from .fanficfare.six import text_type as unicode
+try:
+    from .fanficfare.six import text_type as unicode
+except:
+    from fanficfare.six import text_type as unicode
 
 try:
     from calibre.ebooks.covers import generate_cover as cal_generate_cover
@@ -93,8 +96,11 @@ from calibre_plugins.fanficfare_plugin.dialogs import (
     UPDATE, UPDATEALWAYS, collision_order, save_collisions, RejectListDialog,
     EditTextDialog, IniTextDialog, RejectUrlEntry)
 
-from calibre_plugins.fanficfare_plugin.fanficfare.adapters import (
-    getSiteSections, get_section_url)
+try:
+    from calibre_plugins.fanficfare_plugin.fanficfare.adapters import (
+        getSiteSections, get_section_url)
+except:
+    from fanficfare.adapters import getSiteSections, get_section_url
 
 from calibre_plugins.fanficfare_plugin.common_utils import (
     KeyboardConfigDialog, PrefsViewerDialog, busy_cursor )

--- a/calibre-plugin/dialogs.py
+++ b/calibre-plugin/dialogs.py
@@ -53,7 +53,10 @@ from calibre.gui2 import gprefs
 show_download_options = 'fff:add new/update dialogs:show_download_options'
 from calibre.gui2.dialogs.confirm_delete import confirm
 from calibre.gui2.complete2 import EditWithComplete
-from .fanficfare.six import text_type as unicode, ensure_text
+try:
+    from .fanficfare.six import text_type as unicode, ensure_text
+except:
+    from fanficfare.six import text_type as unicode, ensure_text
 
 # pulls in translation files for _() strings
 try:
@@ -66,13 +69,20 @@ from calibre_plugins.fanficfare_plugin.common_utils import (
     SizePersistedDialog, EditableTableWidgetItem,
     ImageTitleLayout, get_icon)
 
-from calibre_plugins.fanficfare_plugin.fanficfare.geturls import (
-    get_urls_from_mime)
-from calibre_plugins.fanficfare_plugin.fanficfare.adapters import getNormalStoryURL
+try:
+    from calibre_plugins.fanficfare_plugin.fanficfare.geturls import (
+        get_urls_from_mime)
+    from calibre_plugins.fanficfare_plugin.fanficfare.adapters import getNormalStoryURL
 
-from calibre_plugins.fanficfare_plugin.fanficfare.configurable import (
-    get_valid_sections, get_valid_entries,
-    get_valid_keywords, get_valid_entry_keywords)
+    from calibre_plugins.fanficfare_plugin.fanficfare.configurable import (
+        get_valid_sections, get_valid_entries,
+        get_valid_keywords, get_valid_entry_keywords)
+except:
+    from fanficfare.geturls import get_urls_from_mime
+    from fanficfare.adapters import getNormalStoryURL
+    from fanficfare.configurable import (
+            get_valid_sections, get_valid_entries,
+            get_valid_keywords, get_valid_entry_keywords)
 
 from .inihighlighter import IniHighlighter
 
@@ -1691,5 +1701,3 @@ def question_dialog_all(parent, title, msg, det_msg='', show_copy_button=False,
         gprefs.set('questions_to_auto_skip', list(auto_skip))
 
     return ret
-
-

--- a/calibre-plugin/fff_plugin.py
+++ b/calibre-plugin/fff_plugin.py
@@ -9,7 +9,10 @@ __license__   = 'GPL v3'
 __copyright__ = '2021, Jim Miller'
 __docformat__ = 'restructuredtext en'
 
-from .fanficfare.six import ensure_text, string_types, text_type as unicode
+try:
+    from .fanficfare.six import ensure_text, string_types, text_type as unicode
+except:
+    from fanficfare.six import ensure_text, string_types, text_type as unicode
 
 # import cProfile
 
@@ -80,16 +83,25 @@ from calibre_plugins.fanficfare_plugin.common_utils import (
     set_plugin_icon_resources, get_icon, create_menu_action_unique,
     busy_cursor)
 
-from calibre_plugins.fanficfare_plugin.fanficfare import (
-    adapters, exceptions)
+try:
+    from calibre_plugins.fanficfare_plugin.fanficfare import (
+        adapters, exceptions)
 
-from calibre_plugins.fanficfare_plugin.fanficfare.epubutils import (
-    get_dcsource, get_dcsource_chaptercount, get_story_url_from_epub_html,
-    get_story_url_from_zip_html, reset_orig_chapters_epub, get_cover_data)
+    from calibre_plugins.fanficfare_plugin.fanficfare.epubutils import (
+        get_dcsource, get_dcsource_chaptercount, get_story_url_from_epub_html,
+        get_story_url_from_zip_html, reset_orig_chapters_epub, get_cover_data)
 
-from calibre_plugins.fanficfare_plugin.fanficfare.geturls import (
-    get_urls_from_page, get_urls_from_text,get_urls_from_imap,
-    get_urls_from_mime)
+    from calibre_plugins.fanficfare_plugin.fanficfare.geturls import (
+        get_urls_from_page, get_urls_from_text,get_urls_from_imap,
+        get_urls_from_mime)
+except:
+    from fanficfare import adapters, exceptions
+    from fanficfare.epubutils import (
+        get_dcsource, get_dcsource_chaptercount, get_story_url_from_epub_html,
+        get_story_url_from_zip_html, reset_orig_chapters_epub, get_cover_data)
+    from fanficfare.geturls import (
+        get_urls_from_page, get_urls_from_text,get_urls_from_imap,
+        get_urls_from_mime)
 
 from calibre_plugins.fanficfare_plugin.fff_util import (
     get_fff_adapter, get_fff_config, get_fff_personalini,
@@ -2988,4 +3000,3 @@ def pretty_book(d, indent=0, spacer='     '):
         return '\n'.join(['%s%s:\n%s' % (kindent, k, pretty_book(v, indent + 1, spacer))
                           for k, v in d.items()])
     return "%s%s"%(kindent, d)
-

--- a/calibre-plugin/fff_util.py
+++ b/calibre-plugin/fff_util.py
@@ -15,11 +15,18 @@ from io import StringIO
 import logging
 logger = logging.getLogger(__name__)
 
-from calibre_plugins.fanficfare_plugin.fanficfare import adapters
-from calibre_plugins.fanficfare_plugin.fanficfare.configurable import Configuration
+try:
+    from calibre_plugins.fanficfare_plugin.fanficfare import adapters
+    from calibre_plugins.fanficfare_plugin.fanficfare.configurable import Configuration
+    from .fanficfare.six import ensure_text
+    from .fanficfare.six.moves import configparser
+except:
+    from fanficfare import adapters
+    from fanficfare.configurable import Configuration
+    from fanficfare.six import ensure_text
+    from fanficfare.six.moves import configparser
+
 from calibre_plugins.fanficfare_plugin.prefs import prefs
-from .fanficfare.six import ensure_text
-from .fanficfare.six.moves import configparser
 
 def get_fff_personalini():
     return prefs['personal.ini']

--- a/calibre-plugin/inihighlighter.py
+++ b/calibre-plugin/inihighlighter.py
@@ -17,7 +17,10 @@ try:
 except ImportError as e:
     from PyQt4.Qt import (QApplication, Qt, QColor, QSyntaxHighlighter, QTextCharFormat, QBrush, QFont)
 
-from .fanficfare.six import string_types
+try:
+    from .fanficfare.six import string_types
+except:
+    from fanficfare.six import string_types
 
 class IniHighlighter(QSyntaxHighlighter):
     '''

--- a/calibre-plugin/jobs.py
+++ b/calibre-plugin/jobs.py
@@ -20,8 +20,12 @@ from calibre.utils.ipc.server import Server
 from calibre.utils.ipc.job import ParallelJob
 from calibre.constants import numeric_version as calibre_version
 from calibre.utils.date import local_tz
-from .fanficfare.six import text_type as unicode
-from .fanficfare.six.moves.queue import Empty
+try:
+    from .fanficfare.six import text_type as unicode
+    from .fanficfare.six.moves.queue import Empty
+except:
+    from fanficfare.six import text_type as unicode
+    from fanficfare.six.moves.queue import Empty
 
 from calibre_plugins.fanficfare_plugin.wordcount import get_word_count
 from calibre_plugins.fanficfare_plugin.prefs import (SAVE_YES, SAVE_YES_UNLESS_SITE)
@@ -203,8 +207,12 @@ def do_download_for_worker(book,options,merge,notification=lambda x,y:x):
                   # plug impl.
         from calibre_plugins.fanficfare_plugin.dialogs import NotGoingToDownload
         from calibre_plugins.fanficfare_plugin.prefs import (OVERWRITE, OVERWRITEALWAYS, UPDATE, UPDATEALWAYS, ADDNEW, SKIP, CALIBREONLY, CALIBREONLYSAVECOL)
-        from calibre_plugins.fanficfare_plugin.fanficfare import adapters, writers
-        from calibre_plugins.fanficfare_plugin.fanficfare.epubutils import get_update_data
+        try:
+            from calibre_plugins.fanficfare_plugin.fanficfare import adapters, writers
+            from calibre_plugins.fanficfare_plugin.fanficfare.epubutils import get_update_data
+        except:
+            from fanficfare import adapters, writers
+            from fanficfare.epubutils import get_update_data
 
         from calibre_plugins.fanficfare_plugin.fff_util import get_fff_config
 

--- a/calibre-plugin/wordcount.py
+++ b/calibre-plugin/wordcount.py
@@ -18,7 +18,10 @@ logger = logging.getLogger(__name__)
 import re
 
 from calibre.ebooks.oeb.iterator import EbookIterator
-from .fanficfare.six import text_type as unicode
+try:
+    from .fanficfare.six import text_type as unicode
+except:
+    from fanficfare.six import text_type as unicode
 
 RE_HTML_BODY = re.compile(u'<body[^>]*>(.*)</body>', re.UNICODE | re.DOTALL | re.IGNORECASE)
 RE_STRIP_MARKUP = re.compile(u'<[^>]+>', re.UNICODE)

--- a/makeplugin.py
+++ b/makeplugin.py
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
+import sys, os
 from glob import glob
 
 from makezip import createZipFile
@@ -23,7 +23,7 @@ from makezip import createZipFile
 if __name__=="__main__":
     filename="FanFicFare.zip"
     exclude=['*.pyc','*~','*.xcf','*[0-9].png','*.po','*.pot','*default.mo','*Thumbs.db']
-    
+
     os.chdir('calibre-plugin')
     files=['plugin-defaults.ini','plugin-example.ini','about.html',
            'images','translations']
@@ -33,6 +33,13 @@ if __name__=="__main__":
     createZipFile("../"+filename,"w",
                   files,
                   exclude=exclude)
+
+    try:
+        if sys.argv[1] == 'system':
+            print("creating system-only plugin (requires fanficfare installed into calibre's python)")
+            sys.exit()
+    except IndexError:
+        pass
 
     os.chdir('../included_dependencies')
     files=['bs4','chardet','html2text','soupsieve','backports',
@@ -49,4 +56,3 @@ if __name__=="__main__":
     createZipFile(filename,"a",
                   files,
                   exclude=exclude)
-


### PR DESCRIPTION
In current development versions of calibre, Linux distributions can pass an install-time option when building from-source versions of calibre, adding a system path for additional plugins.

Let FanFicFare's plugin be built in such a way that it can be installed as a system plugin, depending on the version of fanficfare that is installed to the global PYTHONPATH rather than bundling it and all third-party dependencies into FanFicFare.zip