### PR TITLE
remove empty paragraph tags

### DIFF
--- a/fanficfare/adapters/adapter_royalroadcom.py
+++ b/fanficfare/adapters/adapter_royalroadcom.py
@@ -215,6 +215,11 @@ class RoyalRoadAdapter(BaseSiteAdapter):
         if None == div:
             raise exceptions.FailedToDownload("Error downloading Chapter: %s!  Missing required element!" % url)
 
+        # strips empty <p> </p> tags that do nothing but add excessive whitespace
+        for tag in soup.find_all('p'):
+            if len(tag.get_text(strip = True)) == 0:
+                tag.extract()
+
         if self.getConfig("include_author_notes",True):
             # collect both first, changing div for frontnote first
             # causes confusion in the tree.


### PR DESCRIPTION
I don't know that this (in the adapter) is the right place to do this. It's an issue on the site itself, maybe it should be a calibre post-processing step, maybe it should be a general ebook output thing. Let me know if it's inappropriate. 

Anyway, the issue is that the spacing on many RoyalRoad stories has been driving me insane: paragraphs are separated with what looks like three newlines rather than one. This makes for a pretty bad reading experience on kindle. 

Looking into it, the culprit is empty `<p> </p>` tags between paragraphs. I wrote three lines of code in the royalroad adapter to fix the issue, and the fix works.