### PR TITLE
nsapa_proxy: Fix truncated reply

### DIFF
--- a/fanficfare/nsapa_proxy.py
+++ b/fanficfare/nsapa_proxy.py
@@ -15,93 +15,158 @@
 # limitations under the License.
 #
 
+import base64
 import time
 import logging
 logger = logging.getLogger(__name__)
 
+from . import exceptions
 from .fetcher import RequestsFetcher, FetcherResponse, make_log
 
 import socket
-class NSAPA_ProxyFetcher(RequestsFetcher):
-    def __init__(self,getConfig_fn,getConfigList_fn):
-        super(NSAPA_ProxyFetcher,self).__init__(getConfig_fn,getConfigList_fn)
 
-    def proxy_request(self,url):
+
+class NSAPA_ProxyFetcher(RequestsFetcher):
+    def __init__(self, getConfig_fn, getConfigList_fn):
+        super(NSAPA_ProxyFetcher, self).__init__(getConfig_fn,
+                                                 getConfigList_fn)
+
+    def proxy_request(self, url, timeout=5):
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.setblocking(True)
-        s.connect((self.getConfig("nsapa_proxy_address","127.0.0.1"),
-                   int(self.getConfig("nsapa_proxy_port",8888))))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        s.connect((self.getConfig("nsapa_proxy_address", "127.0.0.1"),
+                   int(self.getConfig("nsapa_proxy_port", 8888))))
         #logger.debug('Sending URL to socket')
         sent = s.sendall(url.encode('utf-8'))
         if sent == 0:
-            logging.debug('Connection lost during sending')
+            logger.debug('Connection lost during sending')
 
-        header_raw = s.recv(4096)
+        header_raw = s.recv(1024)
         header = header_raw.split(b'$END_OF_HEADER$')[0].decode('utf-8')
+
+        # If we received a part of the payload here, save it
+        # so we can inject it before the payload receive loop
+        pre_data = None
+        if len(header_raw.split(b'$END_OF_HEADER$')) > 1:
+            pre_data = header_raw.split(b'$END_OF_HEADER$')[1]
+
         size_expected = int(header.split('||')[0])
         type_expected = header.split('||')[1]
         logger.debug('Expecting %i bytes of %s', size_expected, type_expected)
 
-        chunks = []
+        # Payload receive loop
         bytes_recd = 0
 
-        while bytes_recd <= size_expected:
-            chunk = s.recv(4096)
-            #logger.debug('Receiving %i bytes from socket', bytes_recd)
-            #if len(chunk.split(b'$END_OF_HEADER$')) > 1:
-                # We have part of the header in our chunk!
-                #chunk = chunk.split(b'$END_OF_HEADER$')[1]
-            if chunk == b'':
-                logging.debug('connection closed by remote host')
+        #Based on code from https://code.activestate.com/recipes/408859/
+        #Licenced under PSF by John Nielsen
+        s.setblocking(False)
+        total_data = []
+        data = ''
+        begin = time.time()
+
+        if pre_data is not None:
+            if len(pre_data) > 0:
+                total_data.append(pre_data)
+                bytes_recd += len(pre_data)
+                logger.debug("Injecting %i bytes from the first recv()",
+                             bytes_recd)
+
+        while True:
+            # We received everything we expected
+            if bytes_recd == size_expected:
+                logger.debug('exiting receive loop after %i bytes', bytes_recd)
                 break
-            chunks.append(chunk)
-            bytes_recd = bytes_recd + len(chunk)
-        logger.debug('closing connection after %i bytes', bytes_recd)
+            #if you got some data, then break after wait sec
+            if total_data and time.time() - begin > timeout:
+                logger.debug("timeout while receiving data")
+                break
+            #if you got no data at all, wait a little longer
+            elif time.time() - begin > timeout * 2:
+                logger.debug("socket timeout (%i seconds)", timeout)
+                break
+            try:
+                data = s.recv(8192)
+                if data:
+                    total_data.append(data)
+                    bytes_recd += len(data)
+                    begin = time.time()
+                else:
+                    time.sleep(0.1)
+            except:
+                pass
+        #End of Code from https://code.activestate.com/recipes/408859/
+        logger.debug('leaving receiving loop after %i bytes', bytes_recd)
 
         s.close()
 
+        if bytes_recd != size_expected:
+            # Truncated reply, log the issue
+            logger.error(
+                'truncated reply from proxy! Expected %i bytes, received %i! '
+                % (size_expected, bytes_recd))
+            raise exceptions.FailedToDownload(
+                'nsapa_proxy: truncated reply from proxy')
+
         if type_expected == 'text':
-            content = b''.join(chunks).decode("utf-8")
+            content = b''.join(total_data).decode("utf-8")
+
+        if type_expected == 'text-b64':
+            content = b''.join(total_data).decode("utf-8")
+            try:
+                content = base64.standard_b64decode(content)
+            except binascii.Error:
+                raise exceptions.FailedToDownload(
+                    'nsapa_proxy: base64 decoding failed')
 
         if type_expected == 'image':
-            content = b''.join(chunks)
+            content = b''.join(total_data)
             #logger.debug('Got %i bytes of image', len(content))
 
         if type_expected == 'binary':
             raise NotImplementedError()
 
-        # return (type,expected_size,received_size,content_as_bytes)
-        return (type_expected,size_expected,bytes_recd,content)
+        return (type_expected, content)
 
-    def request(self,method,url,headers=None,parameters=None):
+    def request(self, method, url, headers=None, parameters=None):
         if method != 'GET':
             raise NotImplementedError()
 
-        logger.debug(make_log('NSAPA_ProxyFetcher',method,url,hit='REQ',bar='-'))
+        logger.debug(
+            make_log('NSAPA_ProxyFetcher', method, url, hit='REQ', bar='-'))
         content = b'initial_data'
         retry_count = 0
-        while (retry_count < 5): #FIXME: make the retry counter configurable
-            (type_expected,size_expected,received_size,content) = self.proxy_request(url)
+        timeout = 5
+        while (retry_count < 5):  #FIXME: make the retry counter configurable
+            try:
+                timeout = timeout + retry_count * 5
+                logger.debug("setting timeout to %i seconds", timeout)
 
-            if received_size == size_expected:
-                # Everything normal
-                retry_count = 0
+                (type_expected, content) = self.proxy_request(url, timeout)
+                # Everything is fine, escape the retry loop
+                retry_count = 6
                 break
 
-            # Truncated reply, log the issue
-            logger.error('truncated reply from proxy! Expected %i bytes, received %i! ' % (size_expected, received_size))
+            except exceptions.FailedToDownload:
+                logger.debug('resetting the browser state')
+                self.proxy_request(
+                    'chrome://version'
+                )  # Loading a very simple website seem to 'fix' this
+                logger.debug('waiting 5 seconds to let the browser settle')
+                time.sleep(5)
 
-            logger.debug('resetting the browser state')
-            self.proxy_request('http://www.example.com') # Loading a very simple website seem to 'fix' this
-            logger.debug('waiting 5 seconds to let the browser settle')
-            time.sleep(5)
+            except NotImplementedError:
+                raise NotImplementedError()
 
-            retry_count += 1
+            finally:
+                retry_count += 1
+                #Needed to catch the raise
+                continue
 
         if retry_count == 5:
             # We exited the retry loop without any valid content,
-            raise exceptions.FailedToDownload('nsapa_proxy: truncated reply from proxy')
+            raise exceptions.FailedToDownload(
+                'nsapa_proxy: truncated reply from proxy after %i retry' %
+                retry_count)
 
-        return FetcherResponse(content,
-                                   url,
-                                   False)
+        return FetcherResponse(content, url, False)


### PR DESCRIPTION
Hello,

After receiving the issue of an user having a lot a truncated reply error from the proxy (nsapa/fanfictionnet_ff_proxy#1), I finally found the cause of the issue.

So this PR:
* fix the receive loop to no discard part of the payload (that fix the truncated reply error)
* switch to a non blocking receive loop
* implement base64 decoding a text reply (not used by default)
* stop using example.com to reset the proxy state (it now use an internal chrome page)
* detect when the proxy is unavailable
* import fanficfare.exceptions
* reformat the code with yapf

Best regards,
NS