### PR TITLE
Flaresolverr proxy add option to specify protocol

### DIFF
--- a/fanficfare/configurable.py
+++ b/fanficfare/configurable.py
@@ -496,6 +496,7 @@ def get_valid_keywords():
                  'use_flaresolverr_proxy',
                  'flaresolverr_proxy_address',
                  'flaresolverr_proxy_port',
+                 'flaresolverr_proxy_protocol',
                  'browser_cache_path',
                  'browser_cache_age_limit',
                  'user_agent',

--- a/fanficfare/flaresolverr_proxy.py
+++ b/fanficfare/flaresolverr_proxy.py
@@ -53,7 +53,8 @@ class FlareSolverr_ProxyFetcher(RequestsFetcher):
             # manually setting the session causes FS to use that
             # string as the session id.
             resp = self.super_request('POST',
-                                      'http://'+self.getConfig("flaresolverr_proxy_address", "localhost")+\
+                                      self.getConfig("flaresolverr_proxy_protocol", "http")+'://'+\
+                                      self.getConfig("flaresolverr_proxy_address", "localhost")+\
                                           ':'+self.getConfig("flaresolverr_proxy_port", '8191')+'/v1',
                                       headers={'Content-Type':'application/json'},
                                       json={'cmd':'sessions.create',
@@ -78,7 +79,8 @@ class FlareSolverr_ProxyFetcher(RequestsFetcher):
             fs_data['session']=self.fs_session
 
         return self.super_request('POST',
-                                  'http://'+self.getConfig("flaresolverr_proxy_address", "localhost")+\
+                                  self.getConfig("flaresolverr_proxy_protocol", "http")+'://'+\
+                                  self.getConfig("flaresolverr_proxy_address", "localhost")+\
                                       ':'+self.getConfig("flaresolverr_proxy_port", '8191')+'/v1',
                                   headers={'Content-Type':'application/json'},
                                   json=fs_data,


### PR DESCRIPTION
Add an option to specify the protocol to use for flaresolverr.
This allows usage of flaresolverr over https.