### PR TITLE
Support for deviantArt (closes #374)

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -3780,3 +3780,5 @@ extra_valid_entries:tags
 ## Clear FanFiction from defaults, site is original fiction.
 extratags:
 
+[www.deviantart.com]
+use_basic_cache:true

--- a/fanficfare/adapters/__init__.py
+++ b/fanficfare/adapters/__init__.py
@@ -164,6 +164,7 @@ from . import adapter_squidgeworldorg
 from . import adapter_novelfull
 from . import adapter_worldofxde
 from . import adapter_psychficcom
+from . import adapter_deviantartcom
 
 ## This bit of complexity allows adapters to be added by just adding
 ## importing.  It eliminates the long if/else clauses we used to need

--- a/fanficfare/adapters/adapter_deviantartcom.py
+++ b/fanficfare/adapters/adapter_deviantartcom.py
@@ -162,6 +162,10 @@ class DeviantArtComSiteAdapter(BaseSiteAdapter):
         data = self.get_request(url)
         soup = self.make_soup(data)
 
+        # remove comments section to avoid false matches
+        comments = soup.select_one('[data-hook=comments_thread]')
+        comments.decompose()
+
         content = soup.select_one('[data-id=rich-content-viewer]')
         if content is None:
             # older story

--- a/fanficfare/adapters/adapter_deviantartcom.py
+++ b/fanficfare/adapters/adapter_deviantartcom.py
@@ -37,7 +37,7 @@ def getClass():
 class DeviantArtComSiteAdapter(BaseSiteAdapter):
     def __init__(self, config, url):
         BaseSiteAdapter.__init__(self, config, url)
-        self.story.setMetadata('siteabbrev', 'deviantartcom')
+        self.story.setMetadata('siteabbrev', 'dac')
 
         self.username = 'NoneGiven'
         self.password = ''

--- a/fanficfare/adapters/adapter_deviantartcom.py
+++ b/fanficfare/adapters/adapter_deviantartcom.py
@@ -64,6 +64,10 @@ class DeviantArtComSiteAdapter(BaseSiteAdapter):
         return ['www.deviantart.com']
 
     @classmethod
+    def getProtocol(self):
+        return 'https'
+
+    @classmethod
     def getSiteExampleURLs(cls):
         return 'https://%s/<author>/art/<work-name>' % cls.getSiteDomain()
 
@@ -154,6 +158,11 @@ class DeviantArtComSiteAdapter(BaseSiteAdapter):
         self.story.setMetadata('datePublished', datetime.strptime(pubdate, '%Y-%m-%dT%H:%M:%S.%f%z'))
 
         # do description here if appropriate
+
+        story_tags = soup.select('a[href^="https://www.deviantart.com/tag"] span')
+        if story_tags is not None:
+            for tag in story_tags:
+                self.story.addToList('genre', tag.get_text())
 
         self.add_chapter(title, self.url)
 

--- a/fanficfare/adapters/adapter_deviantartcom.py
+++ b/fanficfare/adapters/adapter_deviantartcom.py
@@ -170,5 +170,9 @@ class DeviantArtComSiteAdapter(BaseSiteAdapter):
         if content is None:
             # older story
             content = soup.select_one('.legacy-journal')
+            if content is None:
+                raise exceptions.FailedToDownload(
+                    'Could not find story text. Please open a bug with the URL %s' % self.url
+                )
 
         return self.utf8FromSoup(url, content)

--- a/fanficfare/adapters/adapter_deviantartcom.py
+++ b/fanficfare/adapters/adapter_deviantartcom.py
@@ -1,0 +1,96 @@
+#  -*- coding: utf-8 -*-
+
+# Copyright 2021 FanFicFare team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from __future__ import absolute_import
+import logging
+import re
+from datetime import datetime
+# py2 vs py3 transition
+from ..six.moves.urllib import parse as urlparse
+
+from .base_adapter import BaseSiteAdapter, makeDate
+from fanficfare.htmlcleanup import stripHTML
+from .. import exceptions as exceptions
+
+logger = logging.getLogger(__name__)
+
+
+def getClass():
+    return DeviantArtComSiteAdapter
+
+
+class DeviantArtComSiteAdapter(BaseSiteAdapter):
+    def __init__(self, config, url):
+        BaseSiteAdapter.__init__(self, config, url)
+        self.story.setMetadata('siteabbrev', 'deviantart')
+
+        match = re.match(self.getSiteURLPattern(), url)
+        if not match:
+            raise exceptions.InvalidStoryURL(url, self.getSiteDomain(), self.getSiteExampleURLs())
+
+        story_id = match.group('id')
+        author = match.group('author')
+        self.story.setMetadata('storyId', story_id)
+        self.story.setMetadata('author', author)
+        self.story.setMetadata('authorId', author)
+        self.story.setMetadata('authorUrl', 'https://www.deviantart.com/' + author)
+        self._setURL(url)
+
+    @staticmethod
+    def getSiteDomain():
+        return 'www.deviantart.com'
+
+    @classmethod
+    def getAcceptDomains(cls):
+        return ['www.deviantart.com']
+
+    @classmethod
+    def getSiteExampleURLs(cls):
+        return 'https://%s/<author>/art/<work-name>' % cls.getSiteDomain()
+
+    def getSiteURLPattern(self):
+        return r'https?://www\.deviantart\.com/(?P<author>[^/]+)/art/(?P<id>[^/]+)/?'
+
+    def extractChapterUrlsAndMetadata(self):
+        logger.debug('URL: %s', self.url)
+
+        data = self.get_request(self.url)
+
+        soup = self.make_soup(data)
+
+        title = soup.select_one('h1').get_text()
+        self.story.setMetadata('title', title)
+
+        ## dA has no concept of status
+        # self.story.setMetadata('status', 'Completed')
+
+        pubdate = soup.select_one('time')['datetime']
+        self.story.setMetadata('datePublished', datetime.strptime(pubdate, '%Y-%m-%dT%H:%M:%S.%f%z'))
+
+        # do description here if appropriate
+
+        self.add_chapter(title, self.url)
+
+    def getChapterText(self, url):
+        logger.debug('Getting chapter text from: %s', url)
+        data = self.get_request(url)
+        soup = self.make_soup(data)
+
+        content = soup.select_one('.legacy-journal')
+
+        return self.utf8FromSoup(url, content)

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -3784,3 +3784,5 @@ extra_valid_entries:tags
 ## Clear FanFiction from defaults, site is original fiction.
 extratags:
 
+[www.deviantart.com]
+use_basic_cache:true


### PR DESCRIPTION
This is basic support for pulling literature posts from deviantArt, as requested in #374. Multi-chapter stories can be downloaded using the anthology feature, with `include_titlepage:false` if the intermediary title pages aren't desirable.

I have enabled `use_basic_cache` as otherwise each work seems to be downloaded twice unnecessarily.

This is the set of works I used to test this implementation https://www.deviantart.com/begorle01/gallery/23850361/dark-descendents?page=2