### PR TITLE
Deviantart date fix (closes #768), also ID and tag changes

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -3782,3 +3782,5 @@ extratags:
 
 [www.deviantart.com]
 use_basic_cache:true
+## Clear FanFiction from defaults, dA also hosts original fiction.
+extratags:

--- a/fanficfare/adapters/adapter_deviantartcom.py
+++ b/fanficfare/adapters/adapter_deviantartcom.py
@@ -19,7 +19,6 @@
 from __future__ import absolute_import
 import logging
 import re
-from datetime import datetime
 # py2 vs py3 transition
 from ..six.moves.urllib import parse as urlparse
 
@@ -154,8 +153,8 @@ class DeviantArtComSiteAdapter(BaseSiteAdapter):
         ## dA has no concept of status
         # self.story.setMetadata('status', 'Completed')
 
-        pubdate = soup.select_one('time')['datetime']
-        self.story.setMetadata('datePublished', datetime.strptime(pubdate, '%Y-%m-%dT%H:%M:%S.%f%z'))
+        pubdate = soup.select_one('time').get_text()
+        self.story.setMetadata('datePublished', makeDate(pubdate, '%b %d, %Y'))
 
         # do description here if appropriate
 

--- a/fanficfare/adapters/adapter_deviantartcom.py
+++ b/fanficfare/adapters/adapter_deviantartcom.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import
 import logging
 import re
 # py2 vs py3 transition
-from ..six.moves.urllib import parse as urlparse
+from ..six.moves.urllib.parse import urlparse
 
 from .base_adapter import BaseSiteAdapter, makeDate
 from fanficfare.htmlcleanup import stripHTML
@@ -48,7 +48,6 @@ class DeviantArtComSiteAdapter(BaseSiteAdapter):
 
         story_id = match.group('id')
         author = match.group('author')
-        self.story.setMetadata('storyId', story_id)
         self.story.setMetadata('author', author)
         self.story.setMetadata('authorId', author)
         self.story.setMetadata('authorUrl', 'https://www.deviantart.com/' + author)
@@ -146,6 +145,10 @@ class DeviantArtComSiteAdapter(BaseSiteAdapter):
                         'Deviation is set as mature, you must go into your account ' +
                         'and enable showing of mature content.'
                     )
+
+        appurl = soup.select_one('meta[property="da:appurl"]')['content']
+        story_id = urlparse(appurl).path.lstrip('/')
+        self.story.setMetadata('storyId', story_id)
 
         title = soup.select_one('h1').get_text()
         self.story.setMetadata('title', stripHTML(title))

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -3786,3 +3786,5 @@ extratags:
 
 [www.deviantart.com]
 use_basic_cache:true
+## Clear FanFiction from defaults, dA also hosts original fiction.
+extratags:


### PR DESCRIPTION
This fixes the date parsing on Python 2 failure reported in #768.

In addition I have also changed how the story ID is created, previously this adapter used the end portion of the URL, which I'm not sure is guaranteed to be globally unique. This PR changes it to use the UUID assigned to each deviation, which I discovered is present in the `<head>` of every page. I'm not sure if this counts as a breaking change, so I can revert it if that's an issue.

And finally the `FanFiction` tag is no longer applied to works downloaded from dA by default, since the site also hosts original fiction.