### PR TITLE
Patreon support using the browser cache.

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -3782,3 +3782,7 @@ extratags:
 
 [www.deviantart.com]
 use_basic_cache:true
+
+[www.patreon.com]
+use_browser_cache:true
+extratags:

--- a/fanficfare/adapters/__init__.py
+++ b/fanficfare/adapters/__init__.py
@@ -165,6 +165,7 @@ from . import adapter_novelfull
 from . import adapter_worldofxde
 from . import adapter_psychficcom
 from . import adapter_deviantartcom
+from . import adapter_patreoncom
 
 ## This bit of complexity allows adapters to be added by just adding
 ## importing.  It eliminates the long if/else clauses we used to need

--- a/fanficfare/adapters/adapter_patreoncom.py
+++ b/fanficfare/adapters/adapter_patreoncom.py
@@ -1,0 +1,99 @@
+#  -*- coding: utf-8 -*-
+
+# Copyright 2021 FanFicFare team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from __future__ import absolute_import
+import logging
+import re
+# py2 vs py3 transition
+
+from .base_adapter import BaseSiteAdapter, makeDate
+from fanficfare.htmlcleanup import stripHTML
+from .. import exceptions as exceptions
+
+logger = logging.getLogger(__name__)
+
+
+def getClass():
+    return PatreonComSiteAdapter
+
+class PatreonComSiteAdapter(BaseSiteAdapter):
+    def __init__(self, config, url):
+        BaseSiteAdapter.__init__(self, config, url)
+        self.story.setMetadata('siteabbrev', 'patreon')
+
+        self.is_adult = False
+
+        match = re.match(self.getSiteURLPattern(), url)
+        if not match:
+            raise exceptions.InvalidStoryURL(url, self.getSiteDomain(), self.getSiteExampleURLs())
+
+        story_id = match.group('id')
+        self.story.setMetadata('storyId', story_id)
+        self._setURL(url)
+
+    @staticmethod
+    def getSiteDomain():
+        return 'www.patreon.com'
+
+    @classmethod
+    def getAcceptDomains(cls):
+        return ['www.patreon.com']
+
+    @classmethod
+    def getProtocol(self):
+        return 'https'
+
+    @classmethod
+    def getSiteExampleURLs(cls):
+        return 'https://www.patreon.com/posts/<post-id>' % cls.getSiteDomain()
+
+    def getSiteURLPattern(self):
+        return r'https?://www\.patreon\.com/posts/(?P<id>[^/]+)/?'
+
+    def extractChapterUrlsAndMetadata(self):
+        logger.debug('URL: %s', self.url)
+
+        data = self.get_request(self.url)
+        soup = self.make_soup(data)
+
+        title = soup.select_one('[data-tag="post-title"]').get_text()
+        self.story.setMetadata('title', stripHTML(title))
+
+        author = soup.select_one('[data-tag=metadata-wrapper] > div:first-child > div').get_text()
+        self.story.setMetadata('author', author)
+        self.story.setMetadata('authorId', author)
+        self.story.setMetadata('authorUrl', 'https://www.patreon.com/' + author)
+
+        pubdate = soup.select_one('[data-tag="post-published-at"] span').get_text()
+        self.story.setMetadata('datePublished', makeDate(pubdate, '%b %d, %Y at %I:%M %p'))
+
+        story_tags = soup.select('[data-tag="post-tags"] a p')
+        if story_tags is not None:
+            for tag in story_tags:
+                self.story.addToList('genre', tag.get_text())
+
+        self.add_chapter(title, self.url)
+
+    def getChapterText(self, url):
+        logger.debug('Getting chapter text from: %s', url)
+        data = self.get_request(url)
+        soup = self.make_soup(data)
+
+        content = soup.select_one('[data-tag="post-content"]')
+
+        return self.utf8FromSoup(url, content)

--- a/fanficfare/browsercache/basebrowsercache.py
+++ b/fanficfare/browsercache/basebrowsercache.py
@@ -160,7 +160,12 @@ class BaseBrowserCache(object):
         '''
         if self.age_comp_time > cached_time:
             return
-        if 'fanfiction.net/' in cache_url or 'fictionpress.com/' in cache_url or 'ficbook.net/' in cache_url:
+        if (
+                'fanfiction.net/' in cache_url
+                or 'fictionpress.com/' in cache_url
+                or 'ficbook.net/' in cache_url
+                or 'patreon.com/' in cache_url
+            ):
             minurl = self.minimal_url(self.cache_key_to_url(cache_url))
             # logger.debug("%s -> %s"%(minurl,key))
             (existing_key,existing_time) = self.key_mapping.get(minurl,(None,None))

--- a/fanficfare/configurable.py
+++ b/fanficfare/configurable.py
@@ -203,8 +203,8 @@ def get_valid_set_options():
                ## currently, browser_cache_path is assumed to be
                ## shared and only ffnet uses it so far
                'browser_cache_path':(['defaults'],None,None),
-               'use_browser_cache':(['fanfiction.net','fictionpress.com','ficbook.net'],None,boollist),
-               'use_browser_cache_only':(['fanfiction.net','fictionpress.com','ficbook.net'],None,boollist),
+               'use_browser_cache':(['fanfiction.net','fictionpress.com','ficbook.net','patreon.com'],None,boollist),
+               'use_browser_cache_only':(['fanfiction.net','fictionpress.com','ficbook.net','patreon.com'],None,boollist),
 
                'continue_on_chapter_error':(None,None,boollist),
                'conditionals_use_lists':(None,None,boollist),

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -3786,3 +3786,7 @@ extratags:
 
 [www.deviantart.com]
 use_basic_cache:true
+
+[www.patreon.com]
+use_browser_cache:true
+extratags:


### PR DESCRIPTION
This adds support for Patreon text posts via the browser cache feature. Much like deviantArt the end-user must use anthologies if they're downloading a multi-part story.

One thing I noticed, if you're not logged in, and you load a post from an 18+ profile (e.g. https://www.patreon.com/posts/i-am-apocalypse-51991720 though note this post itself isn't 18+) the cached version will fail to parse. It appears that the in-page JavaScript doesn't actually render the story into the body until after you dismiss the modal, so the browser doesn't cache it. But if you're logged in with an account that allows viewing 18+ content it's rendered such that the browser caches it. So users downloading 18+ content will need to log in, and then hard refresh the page to get FanFicFare to pick it up correctly.

Given the above, the fact that most Patreon content will be behind a login wall, and the inability of FanFicFare to support 2FA logins I have also decided to enable the browser cache feature for Patreon by default, since most content won't be downloadable without it.