### PR TITLE
Make Scribble Hub spoilers & footnotes look nicer

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -3555,11 +3555,11 @@ views_label:Views
 averageWords_label:Average Words (Chapter)
 add_to_titlepage_entries:,views, averageWords, fandoms
 
-## Scribble Hub chapters can include author's notes and news blocks.  We've
-## traditionally included them all in the chapter text, but this allows
-## you to customize which you include.  Copy this parameter to your
-## personal.ini and list the ones you don't want.
-#exclude_notes:authornotes,newsboxes
+## Scribble Hub chapters can include author's notes, news blocks, spoilers,
+## and inline footnotes.  We've traditionally included them all in the chapter
+## text, but this allows you to customize which you include.  Copy this
+## parameter to your personal.ini and list the ones you don't want.
+#exclude_notes:authornotes,newsboxes,spoilers,footnotes
 
 [www.silmarillionwritersguild.org]
 use_basic_cache:true

--- a/fanficfare/adapters/adapter_scribblehubcom.py
+++ b/fanficfare/adapters/adapter_scribblehubcom.py
@@ -314,6 +314,45 @@ class ScribbleHubComAdapter(BaseSiteAdapter): # XXX
                 news.clear()
                 news.append(notes_div)
 
+        if 'spoilers' in exclude_notes:
+            # Remove spoiler boxes
+            for spoiler in div.find('div', {'class' : 'sp-wrap'}):
+                spoiler.decompose()
+        else:
+            # Reformat the spoiler boxes
+            for spoiler in div.find_all('div', {'class' : 'sp-wrap'}):
+                spoiler['class'] = ['fff_chapter_notes']
+                spoiler_div = soup.new_tag('div')
+
+                spoiler_title = spoiler.find('div', {'class' : 'sp-head'})
+                if spoiler_title:
+                    new_tag = soup.new_tag('b')
+                    new_tag.string = spoiler_title.get_text()
+                    spoiler_div.append(new_tag)
+
+                spoiler_body = spoiler.find('div', {'class' : 'sp-body'})
+                if spoiler_body:
+                    # Remove [collapse] text
+                    spoiler_body.find('div', {'class' : 'spdiv'}).decompose()
+
+                    new_tag = soup.new_tag('blockquote')
+                    new_tag.append(spoiler_body)
+                    spoiler_div.append(new_tag)
+
+                # Clear old children from the spoiler box, then add this
+                spoiler.clear()
+                spoiler.append(spoiler_div)
+
+        # Reformat inline footnote popups
+        for footnote in div.find_all('sup', {'class' : 'modern-footnotes-footnote'}):
+            footnote.decompose()
+        for note in div.find_all('span', {'class' : 'modern-footnotes-footnote__note'}):
+            if 'footnotes' in exclude_notes:
+                note.decompose()
+            else:
+                note['class'] = ['fff_inline_footnote']
+                note.string = ' (' + note.get_text() + ')'
+
         if None == div:
             raise exceptions.FailedToDownload("Error downloading Chapter: %s!  Missing required element!" % url)
 

--- a/fanficfare/adapters/adapter_scribblehubcom.py
+++ b/fanficfare/adapters/adapter_scribblehubcom.py
@@ -290,7 +290,7 @@ class ScribbleHubComAdapter(BaseSiteAdapter): # XXX
 
         if 'newsboxes' in exclude_notes:
             # Remove author's notes
-            for news in div.find('div', {'class' : 'wi_news'}):
+            for news in div.find_all('div', {'class' : 'wi_news'}):
                 news.decompose()
         else:
             # Reformat the news boxes
@@ -316,7 +316,7 @@ class ScribbleHubComAdapter(BaseSiteAdapter): # XXX
 
         if 'spoilers' in exclude_notes:
             # Remove spoiler boxes
-            for spoiler in div.find('div', {'class' : 'sp-wrap'}):
+            for spoiler in div.find_all('div', {'class' : 'sp-wrap'}):
                 spoiler.decompose()
         else:
             # Reformat the spoiler boxes

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -3559,11 +3559,11 @@ views_label:Views
 averageWords_label:Average Words (Chapter)
 add_to_titlepage_entries:,views, averageWords, fandoms
 
-## Scribble Hub chapters can include author's notes and news blocks.  We've
-## traditionally included them all in the chapter text, but this allows
-## you to customize which you include.  Copy this parameter to your
-## personal.ini and list the ones you don't want.
-#exclude_notes:authornotes,newsboxes
+## Scribble Hub chapters can include author's notes, news blocks, spoilers,
+## and inline footnotes.  We've traditionally included them all in the chapter
+## text, but this allows you to customize which you include.  Copy this
+## parameter to your personal.ini and list the ones you don't want.
+#exclude_notes:authornotes,newsboxes,spoilers,footnotes
 
 [www.silmarillionwritersguild.org]
 use_basic_cache:true


### PR DESCRIPTION
I've noticed a couple stories recently using spoiler boxes and inline footnotes on Scribble Hub and the default way they were formatted doesn't look all that good so this does what #563 did to author's notes and news boxes to those.

I also added fff_ classes to them and a config option to remove them completely, just like with the other ones. For the inline footnotes I did a new class name, `fff_inline_footnote`, as I don't think there's something else quite like it? It's not like AO3 footnotes where it's at the end it's actually more of just a little definition popup.

<details><summary>Before and after screenshots</summary>

These are from [The Phenomenon](https://www.scribblehub.com/read/384021-the-phenomenon/chapter/384023/) (spoiler boxes, with custom title here) and [Tale of a Fox in Welland](https://www.scribblehub.com/read/392234-tale-of-a-fox-in-welland/chapter/392238/) (inline footnote)

## Before:
![spoiler box](https://user-images.githubusercontent.com/41608708/143764529-f08efd52-b60a-4a40-8b2a-7d3a4670b73d.png)
---
![inline footnote](https://user-images.githubusercontent.com/41608708/143764544-94123e6b-1a50-4664-9027-7dde0c12929c.png)

## After:
![spoiler box](https://user-images.githubusercontent.com/41608708/143764534-3b2ce4ba-deac-454c-a435-76e17cdc03c2.png)
---
![inline footnote](https://user-images.githubusercontent.com/41608708/143764548-8654ee71-12c0-4c3c-b34b-bbf1c6e0000d.png)

</details>