### PR TITLE
Refactor main() in cli.py

### DIFF
--- a/fanficfare/cli.py
+++ b/fanficfare/cli.py
@@ -246,10 +246,12 @@ def main(argv=None,
     else:
         warn = fail = print
 
+    printers = {'warn': warn, 'fail': fail}
+    configs = {'passed_defaultsini': passed_defaultsini,
+               'passed_personalini': passed_personalini}
+
     if options.list:
-        configuration = get_configuration(options.list,
-                                          passed_defaultsini,
-                                          passed_personalini,options)
+        configuration = get_configuration(options.list,options,**configs)
         frompage = get_urls_from_page(options.list, configuration)
         if options.jsonmeta:
             import json
@@ -260,22 +262,18 @@ def main(argv=None,
             print('\n'.join(retlist))
 
     if options.normalize:
-        configuration = get_configuration(options.normalize,
-                                          passed_defaultsini,
-                                          passed_personalini,options)
+        configuration = get_configuration(options.normalize,options,**configs)
         retlist = get_urls_from_page(options.normalize, configuration,normalize=True).get('urllist',[])
         print('\n'.join(retlist))
 
     if options.downloadlist:
-        configuration = get_configuration(options.downloadlist,
-                                          passed_defaultsini,
-                                          passed_personalini,options)
+        configuration = get_configuration(options.downloadlist,options,**configs)
         retlist = get_urls_from_page(options.downloadlist, configuration).get('urllist',[])
         urls.extend(retlist)
 
     if options.imaplist or options.downloadimap:
         # list doesn't have a supported site.
-        configuration = get_configuration('test1.com',passed_defaultsini,passed_personalini,options)
+        configuration = get_configuration('test1.com',options,**configs)
         markread = configuration.getConfig('imap_mark_read') == 'true' or \
             (configuration.getConfig('imap_mark_read') == 'downloadonly' and options.downloadimap)
         retlist = get_urls_from_imap(configuration.getConfig('imap_server'),
@@ -309,10 +307,9 @@ def main(argv=None,
                 try:
                     do_download(url,
                                 options,
-                                passed_defaultsini,
-                                passed_personalini,
-                                warn,
-                                fail)
+                                **printers,
+                                **configs
+                                )
                 except Exception as e:
                     if len(urls) == 1:
                         raise

--- a/fanficfare/cli.py
+++ b/fanficfare/cli.py
@@ -203,6 +203,22 @@ def main(argv=None,
     if options.unverified_ssl:
         parser.error("Option --unverified_ssl removed.\nSet use_ssl_unverified_context:true in ini file or --option instead.")
 
+    if list_only and (args or any((options.downloadimap,
+                                   options.downloadlist))):
+        parser.error('Incorrect arguments: Cannot download and list URLs at the same time.')
+
+    if options.update and options.format != 'epub':
+        parser.error('-u/--update-epub/-U/--update-epub-always only work with epub')
+
+    if options.unnew and options.format != 'epub':
+        parser.error('--unnew only works with epub')
+
+    if not list_only and not (args or any((options.infile,
+                                           options.downloadimap,
+                                           options.downloadlist))):
+        parser.print_help();
+        sys.exit()
+
     if not options.debug:
         logger.setLevel(logging.WARNING)
     else:
@@ -229,22 +245,6 @@ def main(argv=None,
             print("\033[{}m{}\033[0m".format(31, t)) # red
     else:
         warn = fail = print
-
-    if list_only and (args or any((options.downloadimap,
-                                   options.downloadlist))):
-        parser.error('Incorrect arguments: Cannot download and list URLs at the same time.')
-
-    if options.update and options.format != 'epub':
-        parser.error('-u/--update-epub/-U/--update-epub-always only work with epub')
-
-    if options.unnew and options.format != 'epub':
-        parser.error('--unnew only works with epub')
-
-    if not list_only and not (args or any((options.infile,
-                                           options.downloadimap,
-                                           options.downloadlist))):
-        parser.print_help();
-        sys.exit()
 
     if options.list:
         configuration = get_configuration(options.list,

--- a/fanficfare/cli.py
+++ b/fanficfare/cli.py
@@ -189,6 +189,17 @@ def main(argv=None,
     parser = mkParser(bool(passed_defaultsini), parser)
     options, args = parser.parse_args(argv)
 
+    list_only = any((options.imaplist,
+                     options.list,
+                     options.normalize,
+                     ))
+
+    # options.updatealways should also invoke most options.update logic.
+    if options.updatealways:
+        options.update = True
+
+    urls=args
+
     if options.unverified_ssl:
         parser.error("Option --unverified_ssl removed.\nSet use_ssl_unverified_context:true in ini file or --option instead.")
 
@@ -219,26 +230,15 @@ def main(argv=None,
     else:
         warn = fail = print
 
-    list_only = any((options.imaplist,
-                     options.list,
-                     options.normalize,
-                     ))
-
     if list_only and (args or any((options.downloadimap,
                                    options.downloadlist))):
         parser.error('Incorrect arguments: Cannot download and list URLs at the same time.')
-
-    # options.updatealways should also invoke most options.update logic.
-    if options.updatealways:
-        options.update = True
 
     if options.update and options.format != 'epub':
         parser.error('-u/--update-epub/-U/--update-epub-always only work with epub')
 
     if options.unnew and options.format != 'epub':
         parser.error('--unnew only works with epub')
-
-    urls=args
 
     if not list_only and not (args or any((options.infile,
                                            options.downloadimap,

--- a/fanficfare/cli.py
+++ b/fanficfare/cli.py
@@ -189,10 +189,10 @@ def main(argv=None,
     parser = mkParser(bool(passed_defaultsini), parser)
     options, args = parser.parse_args(argv)
 
-    list_only = any((options.imaplist,
-                     options.list,
-                     options.normalize,
-                     ))
+    options.list_only = any((options.imaplist,
+                             options.list,
+                             options.normalize,
+                             ))
 
     # options.updatealways should also invoke most options.update logic.
     if options.updatealways:
@@ -203,8 +203,8 @@ def main(argv=None,
     if options.unverified_ssl:
         parser.error("Option --unverified_ssl removed.\nSet use_ssl_unverified_context:true in ini file or --option instead.")
 
-    if list_only and (args or any((options.downloadimap,
-                                   options.downloadlist))):
+    if options.list_only and (args or any((options.downloadimap,
+                                           options.downloadlist))):
         parser.error('Incorrect arguments: Cannot download and list URLs at the same time.')
 
     if options.update and options.format != 'epub':
@@ -213,9 +213,9 @@ def main(argv=None,
     if options.unnew and options.format != 'epub':
         parser.error('--unnew only works with epub')
 
-    if not list_only and not (args or any((options.infile,
-                                           options.downloadimap,
-                                           options.downloadlist))):
+    if not options.list_only and not (args or any((options.infile,
+                                                   options.downloadimap,
+                                                   options.downloadlist))):
         parser.print_help();
         sys.exit()
 
@@ -301,7 +301,7 @@ def main(argv=None,
                     #print("url: (%s)"%url)
                     urls.append(url)
 
-    if not list_only:
+    if not options.list_only:
         if len(urls) < 1:
             print("No valid story URLs found")
         else:

--- a/fanficfare/cli.py
+++ b/fanficfare/cli.py
@@ -185,8 +185,7 @@ def main(argv=None,
     options, args = parser.parse_args(argv)
 
     if options.unverified_ssl:
-        print("Option --unverified_ssl removed.\nSet use_ssl_unverified_context:true in ini file or --option instead.")
-        return
+        parser.error("Option --unverified_ssl removed.\nSet use_ssl_unverified_context:true in ini file or --option instead.")
 
     if not options.debug:
         logger.setLevel(logging.WARNING)
@@ -197,7 +196,7 @@ def main(argv=None,
 
     if options.version:
         print("Version: %s" % version)
-        return
+        sys.exit()
 
     if options.color:
         if 'Windows' in platform.platform():
@@ -208,7 +207,7 @@ def main(argv=None,
                 print("Option --color will not work on Windows without installing Python package colorama.\nContinue? (y/n)?")
                 if options.interactive:
                     if not sys.stdin.readline().strip().lower().startswith('y'):
-                        return
+                        sys.exit()
                     else:
                         # for non-interactive, default the response to yes and continue processing
                         print('y')
@@ -234,7 +233,7 @@ def main(argv=None,
             print('\n#### %s\nExample URLs:' % site)
             for u in examples:
                 print('  * %s' % u)
-        return
+        sys.exit()
 
     # options.updatealways should also invoke most options.update logic.
     if options.updatealways:
@@ -252,7 +251,7 @@ def main(argv=None,
                                            options.downloadimap,
                                            options.downloadlist))):
         parser.print_help();
-        return
+        sys.exit()
 
     if options.list:
         configuration = get_configuration(options.list,

--- a/fanficfare/cli.py
+++ b/fanficfare/cli.py
@@ -67,8 +67,7 @@ def write_story(config, adapter, writeformat,
 def mkParser(calibre, parser=None):
     # read in args, anything starting with -- will be treated as --<varible>=<value>
     if not parser:
-        parser = OptionParser('usage: %prog [options] [STORYURL]...',
-                              version="Version: %s" % version)
+        parser = OptionParser('usage: %prog [options] [STORYURL]...')
     parser.add_option('-f', '--format', dest='format', default='epub',
                       help='Write story as FORMAT, epub(default), mobi, txt or html.', metavar='FORMAT')
     if calibre:
@@ -164,6 +163,14 @@ def mkParser(calibre, parser=None):
     parser.add_option('--color',
                       action='store_true', dest='color',
                       help='Display a errors and warnings in a contrasting color.  Requires package colorama on Windows.', )
+
+    def printVersion(*args):
+        print("Version: %s" % version)
+        sys.exit()
+
+    parser.add_option('-v', '--version',
+                      action='callback', callback=printVersion,
+                      help='Display version and quit.', )
 
     ## undocumented feature for development use.  Save page cache and
     ## cookies between runs.  Saves in PWD as files global_cache and

--- a/fanficfare/cli.py
+++ b/fanficfare/cli.py
@@ -206,7 +206,7 @@ def validateOptions(parser, options, args):
     if not options.list_only and not (args or any((options.infile,
                                                    options.downloadimap,
                                                    options.downloadlist))):
-        parser.print_help();
+        parser.print_help()
         sys.exit()
 
 def setup(options):


### PR DESCRIPTION
As mentioned in #779, main() as currently written has its various phases all in
one place. This patchset splits them up for readability's sake, though the
extent to which I have succeeded in this is up to the beholder.

Some of the most notable features:
* doc-getting flags (`-v`, `-s`) now short-circuit to avoid setting up FFF
* `main()`'s logic is cleanly separated as a parse/validate/setup/run sequence
* parts of `main()`'s state that belong together are bundled together (eg
  `passed_{defaults,personal}ini`, `fail/warn`, ...)
* key feature: `main()` is broken up into distinct functions

Besides readability, this also improves the ability to script around `cli.py` by
exposing FFF's logic more granularly