### PR TITLE
Fix nested []/()

### DIFF
--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -712,9 +712,9 @@ add_to_replace_metadata:
 # because that's applied to each part after split.
  tagsfromtitledetect=>^[^\]\)]+$=>
 # for QuestionableQuesting NSFW subforum.
- tagsfromtitle=>^\[NSFW\].*?([\(\[]([^\]\)]+)[\)\]]).*?$=>NSFW,\2
+ tagsfromtitle=>^\[NSFW\].*?(\[([^\]]+)\]|\(([^\)]+)\)).*?$=>NSFW\,\2\,\3
 # remove anything outside () or []
- tagsfromtitle=>^.*?([\(\[]([^\]\)]+)[\)\]]).*?$=>\2
+ tagsfromtitle=>^.*?(\[([^\]]+)\]|\(([^\)]+)\)).*?$=>\2\,\3
 # remove () []
 # tagsfromtitle=>[\(\)\[\]]=>
 # shield these html entities from the ';' pattern below
@@ -733,7 +733,7 @@ add_to_replace_metadata:
  tagsfromtitle=>([^,]+),(.+)=>\1\,\2
 
 # remove [] or () blocks and leading/trailing spaces/dashes/colons
- title=>[-: ]*[\(\[]([^\]\)]+)[\)\]][-: ]*=>
+ title=>[-: ]*(\[([^\]]+)\]|\(([^\)]+)\))[-: ]*=>
 # remove 'Thread' and the next word, usually "Thread 2", "Thread
 # four", "Thread iv", "Story Thread", etc
  title,tagsfromtitle=>[-: ,]*(Story *)?[Tt]hread [^ ]+[-: ]*=>


### PR DESCRIPTION
Problem was regexes treated `[,(` and `],)` equally, considering eg `[..)`
balanced.

Considering `()` is also used within titles without signifying tags, it might be
worth investigating only matching that kind of bracketed tag at the end of the
title.

Closes: #782