### PR TITLE
ReadOnlyMindAdapter: Add series_tags feature to populate series metadata

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -2315,6 +2315,11 @@ extra_valid_entries:eroticatags
 eroticatags_label:Erotica Tags
 extra_titlepage_entries: eroticatags
 
+## some tags are used as series identification. There is no way to find a
+## sequence, but at least the stories will be grouped. Use the tag as written
+## without the hash mark
+#series_tags:Human_Domestication_Guide
+
 [samandjack.net]
 ## Some sites require login (or login for some rated stories) The
 ## program can prompt you, or you can save it in config.  In

--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -2317,8 +2317,13 @@ extra_titlepage_entries: eroticatags
 
 ## some tags are used as series identification. There is no way to find a
 ## sequence, but at least the stories will be grouped. Use the tag as written
-## without the hash mark
+## without the hash mark. Keep underscores '_' in, they will be replaced by
+## spaces in the metadata.
 #series_tags:Human_Domestication_Guide
+
+## If you want underscores replaced in the tags:
+#add_to_replace_metadata:
+# eroticatags=>_=>\s
 
 [samandjack.net]
 ## Some sites require login (or login for some rated stories) The

--- a/fanficfare/adapters/adapter_readonlymindcom.py
+++ b/fanficfare/adapters/adapter_readonlymindcom.py
@@ -137,7 +137,7 @@ class ReadOnlyMindComAdapter(BaseSiteAdapter):
                 seriesUrl = baseUrl + a.attrs['href']
                 self.story.setMetadata('seriesUrl', seriesUrl);
             else:
-                self.story.addToList('eroticatags', strippedTag.replace('_', ' '))
+                self.story.addToList('eroticatags', strippedTag)
 
 
         # Publish and update dates

--- a/fanficfare/adapters/adapter_readonlymindcom.py
+++ b/fanficfare/adapters/adapter_readonlymindcom.py
@@ -126,14 +126,23 @@ class ReadOnlyMindComAdapter(BaseSiteAdapter):
 
         # Tags
         # As these are the only tags should they go in categories?
+        # Also check for series tags in config
+        # Unfortunately there's no way to get a meaningful volume number
+        series_tags = self.getConfig('series_tags').split(',')
+
         for a in soup1.find_all('a', class_="tag-link"):
-            self.story.addToList('eroticatags', a.text.strip('#').replace('_', ' '))
+            if a.text.strip('#') in series_tags:
+                self.setSeries(a.text.strip('#').replace('_', ' '), 0)
+                seriesUrl = baseUrl + a.attrs['href']
+                self.story.setMetadata('seriesUrl', seriesUrl);
+            else:
+                self.story.addToList('eroticatags', a.text.strip('#').replace('_', ' '))
+
 
         # Publish and update dates
         publishdate = soup1.find('meta', attrs={"name":"created"})
         pDate = makeDate(publishdate.attrs['content'], self.dateformat)
         if publishdate is not None: self.story.setMetadata('datePublished', pDate)
-        # if updatedate is not None: self.story.setMetadata('dateUpdated', updatedate)
 
         # Get chapter URLs
         chapterTable = soup1.find('section', id='chapter-list')

--- a/fanficfare/adapters/adapter_readonlymindcom.py
+++ b/fanficfare/adapters/adapter_readonlymindcom.py
@@ -131,12 +131,13 @@ class ReadOnlyMindComAdapter(BaseSiteAdapter):
         series_tags = self.getConfig('series_tags').split(',')
 
         for a in soup1.find_all('a', class_="tag-link"):
-            if a.text.strip('#') in series_tags:
-                self.setSeries(a.text.strip('#').replace('_', ' '), 0)
+            strippedTag = a.text.strip('#')
+            if strippedTag in series_tags:
+                self.setSeries(strippedTag.replace('_', ' '), 0)
                 seriesUrl = baseUrl + a.attrs['href']
                 self.story.setMetadata('seriesUrl', seriesUrl);
             else:
-                self.story.addToList('eroticatags', a.text.strip('#').replace('_', ' '))
+                self.story.addToList('eroticatags', strippedTag.replace('_', ' '))
 
 
         # Publish and update dates

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -1234,7 +1234,7 @@ nook_img_fix:true
 ## for series info.  This is not epub standard, but not an
 ## unreasonable thing for FanFicFare to emulate.  This is primarily
 ## useful for CLI and web service--the calibre plugin doesn't need it.
-#calibre_series_meta:true
+#calibre_series_meta:false
 
 [html]
 

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -1234,7 +1234,7 @@ nook_img_fix:true
 ## for series info.  This is not epub standard, but not an
 ## unreasonable thing for FanFicFare to emulate.  This is primarily
 ## useful for CLI and web service--the calibre plugin doesn't need it.
-#calibre_series_meta:false
+#calibre_series_meta:true
 
 [html]
 
@@ -2339,8 +2339,13 @@ extra_titlepage_entries: eroticatags
 
 ## some tags are used as series identification. There is no way to find a
 ## sequence, but at least the stories will be grouped. Use the tag as written
-## without the hash mark
+## without the hash mark. Keep underscores '_' in, they will be replaced by
+## spaces in the metadata.
 #series_tags:Human_Domestication_Guide
+
+## If you want underscores replaced in the tags:
+#add_to_replace_metadata:
+# eroticatags=>_=>\s
 
 [samandjack.net]
 ## Some sites require login (or login for some rated stories) The

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -2337,6 +2337,11 @@ extra_valid_entries:eroticatags
 eroticatags_label:Erotica Tags
 extra_titlepage_entries: eroticatags
 
+## some tags are used as series identification. There is no way to find a
+## sequence, but at least the stories will be grouped. Use the tag as written
+## without the hash mark
+#series_tags:Human_Domestication_Guide
+
 [samandjack.net]
 ## Some sites require login (or login for some rated stories) The
 ## program can prompt you, or you can save it in config.  In


### PR DESCRIPTION
Added an option in config to specify tags that denote a series and write that information into series metadata.

No way to get a meaningful volume number, but grouping is at least possible in e-readers.