### PR TITLE
reworked royalroad paragraph spacing fix

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -3578,6 +3578,9 @@ extratags:
 ## chapter text.
 #include_author_notes:true
 
+## fixes spacing issues with some stories
+keep_empty_tags:div,td,th
+
 ## default formatting for author's notes and tables in the story text
 ## makes some stories drastically easier to visually parse
 add_to_output_css:

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -3582,6 +3582,9 @@ extratags:
 ## chapter text.
 #include_author_notes:true
 
+## fixes spacing issues with some stories
+keep_empty_tags:div,td,th
+
 ## default formatting for author's notes and tables in the story text
 ## makes some stories drastically easier to visually parse
 add_to_output_css:


### PR DESCRIPTION
Now with fewer unintended consequences, and story urls for testing. Hoping to be done with #690 #798 etc.

----------------------

Here's the links to affected stories I've stumbled across. 

First issue is stories using `<div>&nbsp;</div>` for spacing. This is broken in fanficfare, and isn't a problem on the site. It also, IMO, makes stories totally unreadable.

The Flower That Bloomed Nowhere, chapter 25 (& other chapters). ch. 24 is fine. (yes, both chapters have the same name)
https://www.royalroad.com/fiction/28806/the-flower-that-bloomed-nowhere/chapter/570921/025-in-fading-image
https://www.royalroad.com/fiction/28806/the-flower-that-bloomed-nowhere/chapter/569067/024-in-fading-image

12 Miles Below, book 2 chapter 32 (contrast book 2 chapter 31)
https://www.royalroad.com/fiction/42367/12-miles-below/chapter/819477/book-2-chapter-32-kidra-t
https://www.royalroad.com/fiction/42367/12-miles-below/chapter/817701/book-2-chapter-31-bargains-offered-by-the-devil

Wizard's Tower, Ch. 33 (contrast ch.32)
https://www.royalroad.com/fiction/41881/wizards-tower/chapter/677695/chapter-33
https://www.royalroad.com/fiction/41881/wizards-tower/chapter/677105/chapter-32

The second issue is double spacing with `<p></p>` tags. It's extremely annoying to read on a kindle, but true to the site. I'll understand if this is wontfix due to the stories themselves being broken. Still, the inconsistency for some stories suggests that it's not author intent.

Only Villians Do That (entire story)
https://www.royalroad.com/fiction/40182/only-villains-do-that

The Daily Grind, ch.9 and other chapters intermittently
https://www.royalroad.com/fiction/15925/the-daily-grind/chapter/186721/chapter-009

Beware of chicken, v2ch81 onwards
https://www.royalroad.com/fiction/39408/beware-of-chicken/chapter/797029/v2c81-plum-blossom-contemplations

Prophecy Approved Companion (entire story)
https://www.royalroad.com/fiction/35549/prophecy-approved-companion 

------------

There's at least one other royalroad paragraph spacing issue floating around that this doesn't fix.
See The Calamitous Bob, chapter 38 (contrast with ch. 37)
https://www.royalroad.com/fiction/44132/the-calamitous-bob/chapter/744534/chapter-38-mountain-people
For me, this renders differently in the Calibri ebook reader vs the calibri ebook viewer (!) which I'm hoping is some configuration problem on my end, and not the previous changes to author's notes I submitted somehow messing things up.
