### PR TITLE
use large cover images on royalroad

### DIFF
--- a/fanficfare/adapters/adapter_royalroadcom.py
+++ b/fanficfare/adapters/adapter_royalroadcom.py
@@ -221,7 +221,9 @@ class RoyalRoadAdapter(BaseSiteAdapter):
         img = soup.find(None,{'class':'row fic-header'}).find('img')
         if img:
             cover_url = img['src']
-            self.setCoverImage(url,cover_url)
+            # usually URL is for thumbnail. Try expected URL for larger image, if fails fall back to the original URL
+            if self.setCoverImage(url,cover_url.replace('/covers-full/', '/covers-large/'))[0] == "failedtoload":
+                self.setCoverImage(url,cover_url)
                     # some content is show as tables, this will preserve them
 
         itag = soup.find('i',title='Story Length')


### PR DESCRIPTION
royalroad.com cover image links on the story pages are thumbnails. A fixed string replace makes it a link to the larger size image. This patch tries to get the larger image and if that fails falls back to use the actual link that is on the story page.
This was tested on 63 stories on the site, including one that doesn't have the larger cover image and triggered the fallback.