### PR TITLE
fix storiesonline login (again) - parameter name was changed back to …

### DIFF
--- a/fanficfare/adapters/adapter_storiesonlinenet.py
+++ b/fanficfare/adapters/adapter_storiesonlinenet.py
@@ -124,7 +124,7 @@ class StoriesOnlineNetAdapter(BaseSiteAdapter):
             return
         soup = self.make_soup(data)
         params = {}
-        params['username'] = username
+        params['email'] = username
         postAction = soup.find('form')['action']
 
         parsedUrl = urlparse(useurl)


### PR DESCRIPTION
See #839. Parameter is now "email" again instead of "usermane".