### PR TITLE
readonlymind: add option to include foreword/author's note

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -2318,6 +2318,10 @@ website_encodings: utf8:ignore, Windows-1252, iso-8859-1
 ## Login on readonlymind.com is optional and not used for adultcheck
 #is_adult:true
 
+## readonlymind.com chapters may have an author's note attached to them.
+## Setting include_author_notes:true will include it with the chapter text.
+#include_author_notes:false
+
 ## Clear FanFiction from defaults, site is original fiction.
 extratags:Erotica
 

--- a/fanficfare/configurable.py
+++ b/fanficfare/configurable.py
@@ -220,7 +220,7 @@ def get_valid_set_options():
                'fix_fimf_blockquotes':(['fimfiction.net'],None,boollist),
                'fail_on_password':(['fimfiction.net'],None,boollist),
                'keep_prequel_in_description':(['fimfiction.net'],None,boollist),
-               'include_author_notes':(['fimfiction.net','royalroad.com'],None,boollist),
+               'include_author_notes':(['fimfiction.net','readonlymind.com','royalroad.com'],None,boollist),
                'do_update_hook':(['fimfiction.net',
                                   'archiveofourown.org'],None,boollist),
                'always_login':(['archiveofourown.org']+base_xenforo_list,None,boollist),

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -2340,6 +2340,10 @@ website_encodings: utf8:ignore, Windows-1252, iso-8859-1
 ## Login on readonlymind.com is optional and not used for adultcheck
 #is_adult:true
 
+## readonlymind.com chapters may have an author's note attached to them.
+## Setting include_author_notes:true will include it with the chapter text.
+#include_author_notes:false
+
 ## Clear FanFiction from defaults, site is original fiction.
 extratags:Erotica
 


### PR DESCRIPTION
ROM chapters can include an author's note as a foreword on the chapter
page. It's an entirely separate section tag from the story content, so
when it is present, a div tag is used to wrap both.

I tested this patch with some stories from ROM's front page that had:
- some chapters with forewords, some without
- no chapters with forewords
- only chapters with forewords

This is my first PR to this project, so let me know if changes are needed.