### PR TITLE
scribblehub flaresolverr fix

### DIFF
--- a/fanficfare/adapters/adapter_scribblehubcom.py
+++ b/fanficfare/adapters/adapter_scribblehubcom.py
@@ -140,6 +140,14 @@ class ScribbleHubComAdapter(BaseSiteAdapter): # XXX
                             "strSID": self.story.getMetadata('storyId'),
                             "strmypostid": 0,
                             "strFic": "yes"}
+        
+        # 14/12/22 - Looks like it should follow this format now (below), but still returns a 400
+        # but not a 403. tested in browser getting rid of all other cookies to try and get a 400 and nopes. 
+
+        # contents_payload = {"action": "wi_getreleases_pagination",
+        #                     "pagenum": 1,
+        #                     "mypostid": 421879}
+
 
         contents_data = self.post_request("https://www.scribblehub.com/wp-admin/admin-ajax.php", contents_payload)
 

--- a/fanficfare/flaresolverr_proxy.py
+++ b/fanficfare/flaresolverr_proxy.py
@@ -156,7 +156,7 @@ class FlareSolverr_ProxyFetcher(RequestsFetcher):
                 ensure_text(url),
                 status_code,
                 ensure_text(data),
-                ensure_text(data)
+                data
                 )
 
         return FetcherResponse(data,

--- a/fanficfare/flaresolverr_proxy.py
+++ b/fanficfare/flaresolverr_proxy.py
@@ -151,12 +151,13 @@ class FlareSolverr_ProxyFetcher(RequestsFetcher):
                                # 428 ('Precondition Required') gets the
                                # error_msg through to the user.
             data = resp.json['message']
-        if status_code != 200 and status_code != 400: # 400 for scribblehub ajax query 
-                raise exceptions.HTTPErrorFFF(
-                    ensure_text(url),
-                    status_code,
-                    ensure_text(data)
-                    )
+        if status_code != 200:
+            raise exceptions.HTTPErrorFFF(
+                ensure_text(url),
+                status_code,
+                ensure_text(data),
+                ensure_text(data)
+                )
 
         return FetcherResponse(data,
                                url,

--- a/fanficfare/flaresolverr_proxy.py
+++ b/fanficfare/flaresolverr_proxy.py
@@ -151,7 +151,7 @@ class FlareSolverr_ProxyFetcher(RequestsFetcher):
                                # 428 ('Precondition Required') gets the
                                # error_msg through to the user.
             data = resp.json['message']
-        if status_code != 200:
+        if status_code != 200 and status_code != 400: # 400 for scribblehub ajax query 
                 raise exceptions.HTTPErrorFFF(
                     ensure_text(url),
                     status_code,


### PR DESCRIPTION
Hi JimmXinu,

This is a 'fix' for the scribblehub adaptor which currently doesn't work at all. At the moment, by default it returns a 403 for the base url of a fic which genuinly confuses me and I can't find a reason for it - I can't replicate it with curl, and the closest I can get is a cloudlfare page if I don't set the useragent. 

I figured it might be a cookie thing as Scribblehub now have a GDPR prompt, so I tried the flaresolverr plugin. This partially worked, but the part of the script which runs an ajax request for the table of contents returns the correct content but with a 400 code. It's wierd because I can curl that fine, and in the web browser I can do the request successfully even after deleting all the tracking/GDPR cookies and get a 200 back. 

For example: 
``` bash 
curl 'https://www.scribblehub.com/wp-admin/admin-ajax.php' -X POST -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:107.0) Gecko/20100101 Firefox/107.0' -H 'Cookie: toc_show=1; toc_sorder=asc' --data-raw 'action=wi_gettocchp&strSID=421879&strmypostid=0&strFic=yes' -H "Content-Type: application/x-www-form-urlencoded"
```

As a side note, scribblehub do appear to have changed the format of the query to something like this: 

``` python 
contents_payload = {"action": "wi_getreleases_pagination", "pagenum": 1, "mypostid": 421879}
```
Instead of:
```python
contents_payload = {"action": "wi_gettocchp", "strSID": self.story.getMetadata('storyId'), "strmypostid": 0, "strFic": "yes"}
```
However, the previous query payload still works (and works just fine with curl and in the dom explorer in firefox) and the response can be parsed just fine by the rest of the program as is, and both queries return the same 400 code. 

It does feel like a bodge, I have gone through requestable.py, fetcher.py and flaresolverr_proxy.py and as far as I can tell the request is formed correctly. From what I can tell this "fix" will have no impact on using flaresolverr for fanfiction.net, but just allows a 400 to be accepted just like 200 is - it's just super annoying I can't seem replicate getting a 400 code with curl or firefox. 

Tested just on the cli on macos. 