### PR TITLE
Added `fanficfare.fetchers` to packages in `setup.py`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,8 @@ setup(
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
     # packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
-    packages=['fanficfare', 'fanficfare.adapters', 'fanficfare.writers',
+    packages=['fanficfare',
+              'fanficfare.adapters', 'fanficfare.fetchers', 'fanficfare.writers',
               'fanficfare.browsercache','fanficfare.browsercache.chromagnon'],
 
     # for package_data


### PR DESCRIPTION
Fixes the following error when installed by `setup.py`:

```
Traceback (most recent call last):
  File "/usr/bin/fanficfare", line 33, in <module>
    sys.exit(load_entry_point('FanFicFare==4.19.7', 'console_scripts', 'fanficfare')())
  File "/usr/bin/fanficfare", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/lib/python3.10/importlib/metadata/__init__.py", line 171, in load
    module = import_module(match.group('module'))
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/usr/lib/python3.10/site-packages/fanficfare/cli.py", line 46, in <module>
    from fanficfare import adapters, writers, exceptions
  File "/usr/lib/python3.10/site-packages/fanficfare/adapters/__init__.py", line 29, in <module>
    from .. import configurable as configurable
  File "/usr/lib/python3.10/site-packages/fanficfare/configurable.py", line 38, in <module>
    from . import fetchers
ImportError: cannot import name 'fetchers' from 'fanficfare' (/usr/lib/python3.10/site-packages/fanficfare/__init__.py)
```