### PR TITLE
Add keep_in_order_freeformtags:true to AO3

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -1573,6 +1573,10 @@ include_in_category:fandoms
 ## freefromtags will still work for people who've used it.
 include_in_freefromtags:freeformtags
 
+## AO3 authors often enter freeform tags in a specific order to make
+## comments on the story. This preserves the order.
+keep_in_order_freeformtags:true
+
 ## chapterslashtotal contains 1/3 or 1/1 or 3/? etc as reported by AO3.
 ## chapterstotal is just the total chapters part after the /
 include_in_chapterstotal:chapterslashtotal.NOREPL


### PR DESCRIPTION
Added keep_in_order_freeformtags:true to defaults.ini to preserve the order of freeform tags on AO3. Authors sometimes use them in a specific order to make comments on the story.