### PR TITLE
Embiggen epub cover, add stylesheet to cover page

### DIFF
--- a/fanficfare/writers/writer_epub.py
+++ b/fanficfare/writers/writer_epub.py
@@ -184,13 +184,19 @@ ${value}<br />
 ''')
 
         self.EPUB_COVER = string.Template('''
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"><head><title>Cover</title><style type="text/css" title="override_css">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<head>
+<title>Cover</title>
+<link href="stylesheet.css" type="text/css" rel="stylesheet"/>
+<style type="text/css" title="override_css">
 @page {padding: 0pt; margin:0pt}
 body { text-align: center; padding:0pt; margin: 0pt; }
 div { margin: 0pt; padding: 0pt; }
-</style></head><body class="fff_coverpage"><div>
-<img src="${coverimg}" alt="cover"/>
-</div></body></html>
+img { width: 100%; height: auto; }
+</style>
+</head>
+<body class="fff_coverpage"><div><img src="${coverimg}" alt="cover"/></div></body>
+</html>
 ''')
 
     def writeLogPage(self, out):


### PR DESCRIPTION
On my device (Kindle PW3, Koreader 2023.01), stories ([example](https://www.royalroad.com/fiction/62881/reborn-as-a-demonic-tree)) show up with small cover images on the cover page:

![before](https://user-images.githubusercontent.com/10540915/219120613-a630b2a3-d507-45b9-9bd8-e4e7a6b78867.jpeg)

I tried to remedy this by modifying `add_to_output_css` in `personal.ini`, but the stylesheet is not loaded on the cover page.

This change makes the cover image larger, and adds loading the user CSS so this can be further customized without changing the code.

Example after change on my device:
![after](https://user-images.githubusercontent.com/10540915/219120882-d07f603c-17a3-402b-a163-5025c024c455.jpeg)

Note: I am not a competent web designer, and am not certain this is the correct CSS! If you want a lower-risk change, I can modify this to only add the user stylesheet, and not modify the default CSS.