### PR TITLE
Typo fix

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -832,7 +832,7 @@ always_include_first_post:false
 ## version in the first chapter gets out of sync.
 ##
 ## If always_reload_first_chapter:true, then the first chapter will
-## always be downloaded again (ie, reloaded).  It will NOT be maked
+## always be downloaded again (ie, reloaded).  It will NOT be marked
 ## '(new)' (see mark_new_chapters).  Because it is reloaded, manual
 ## edits made to the first chapter will be lost.
 ##

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -832,7 +832,7 @@ always_include_first_post:false
 ## version in the first chapter gets out of sync.
 ##
 ## If always_reload_first_chapter:true, then the first chapter will
-## always be downloaded again (ie, reloaded).  It will NOT be maked
+## always be downloaded again (ie, reloaded).  It will NOT be marked
 ## '(new)' (see mark_new_chapters).  Because it is reloaded, manual
 ## edits made to the first chapter will be lost.
 ##


### PR DESCRIPTION
Fixed a typo in description of always_reload_first_chapter. Updated both defaults and plugin-defaults.