### PR TITLE
Fix for orphan_account authorUrl

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -1577,6 +1577,10 @@ include_in_freefromtags:freeformtags
 include_in_chapterstotal:chapterslashtotal.NOREPL
 add_to_replace_metadata:
  chapterstotal=>^([0-9])+/(.+)$=>\2
+ 
+ ## The link to orphan_account just leads to a 404 page.
+ ## This replaces it with a link to the AO3 homepage.
+  authorUrl=>(https://archiveofourown\.org)/users/orphan_account/pseuds/orphan_account=>\1
 
 ## adds to titlepage_entries instead of replacing it.
 #extra_titlepage_entries: fandoms,freeformtags,ao3categories,comments,chapterslashtotal,chapterstotal,kudos,hits,bookmarks,bookmarked,bookmarktags,bookmarksummary,series01HTML,series02HTML,series03HTML,byline

--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -1580,7 +1580,6 @@ add_to_replace_metadata:
  
  ## Due to a bug with Archive of Our Own, the 
  ## link to orphan_account just leads to a 404 page.
- ## This replaces it with a link to the AO3 homepage.
  ## authorUrl=>(/users/orphan_account)/pseuds/.*$=>\1
 
 ## adds to titlepage_entries instead of replacing it.

--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -1578,9 +1578,10 @@ include_in_chapterstotal:chapterslashtotal.NOREPL
 add_to_replace_metadata:
  chapterstotal=>^([0-9])+/(.+)$=>\2
  
- ## The link to orphan_account just leads to a 404 page.
+ ## Due to a bug with Archive of Our Own, the 
+ ## link to orphan_account just leads to a 404 page.
  ## This replaces it with a link to the AO3 homepage.
-  authorUrl=>(https://archiveofourown\.org)/users/orphan_account/pseuds/orphan_account=>\1
+ ## authorUrl=>(/users/orphan_account)/pseuds/.*$=>\1
 
 ## adds to titlepage_entries instead of replacing it.
 #extra_titlepage_entries: fandoms,freeformtags,ao3categories,comments,chapterslashtotal,chapterstotal,kudos,hits,bookmarks,bookmarked,bookmarktags,bookmarksummary,series01HTML,series02HTML,series03HTML,byline

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -1582,9 +1582,10 @@ include_in_chapterstotal:chapterslashtotal.NOREPL
 add_to_replace_metadata:
  chapterstotal=>^([0-9])+/(.+)$=>\2
  
- ## The link to orphan_account just leads to a 404 page.
+ ## Due to a bug with Archive of Our Own, the 
+ ## link to orphan_account just leads to a 404 page.
  ## This replaces it with a link to the AO3 homepage.
-  authorUrl=>(https://archiveofourown\.org)/users/orphan_account/pseuds/orphan_account=>\1
+ ## authorUrl=>(/users/orphan_account)/pseuds/.*$=>\1
 
 ## adds to titlepage_entries instead of replacing it.
 #extra_titlepage_entries: fandoms,freeformtags,ao3categories,comments,chapterslashtotal,chapterstotal,kudos,hits,bookmarks,bookmarked,bookmarktags,bookmarksummary,series01HTML,series02HTML,series03HTML,byline

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -1584,7 +1584,6 @@ add_to_replace_metadata:
  
  ## Due to a bug with Archive of Our Own, the 
  ## link to orphan_account just leads to a 404 page.
- ## This replaces it with a link to the AO3 homepage.
  ## authorUrl=>(/users/orphan_account)/pseuds/.*$=>\1
 
 ## adds to titlepage_entries instead of replacing it.

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -1581,6 +1581,10 @@ include_in_freefromtags:freeformtags
 include_in_chapterstotal:chapterslashtotal.NOREPL
 add_to_replace_metadata:
  chapterstotal=>^([0-9])+/(.+)$=>\2
+ 
+ ## The link to orphan_account just leads to a 404 page.
+ ## This replaces it with a link to the AO3 homepage.
+  authorUrl=>(https://archiveofourown\.org)/users/orphan_account/pseuds/orphan_account=>\1
 
 ## adds to titlepage_entries instead of replacing it.
 #extra_titlepage_entries: fandoms,freeformtags,ao3categories,comments,chapterslashtotal,chapterstotal,kudos,hits,bookmarks,bookmarked,bookmarktags,bookmarksummary,series01HTML,series02HTML,series03HTML,byline


### PR DESCRIPTION
The authorUrl for AO3's orphan_account leads to a 404 page. Like 'anonymous' authors from collection, this changes to redirect to the AO3 homepage.

`authorUrl=>(https://archiveofourown\.org)/users/orphan_account/pseuds/orphan_account=>\1`