### PR TITLE
Comment about AO3's 'Hide Additional Tags' on login-restricted stories

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -1577,6 +1577,8 @@ make_linkhtml_entries:series00,series01,series02,series03
 ## hardcoded to include the site specific metadata freeformtags &
 ## ao3categories in the standard metadata field genre.  By making it
 ## configurable, users can change it.
+## Note that this may fail for login-restricted stories if the 
+## account used to login has 'Hide Additional Tags' enabled in AO3 settings.
 include_in_genre: freeformtags, ao3categories
 
 ## AO3 uses the word 'category' differently than most sites.  The
@@ -2527,6 +2529,8 @@ make_linkhtml_entries:series00,series01,series02,series03
 ## hardcoded to include the site specific metadata freeformtags &
 ## ao3categories in the standard metadata field genre.  By making it
 ## configurable, users can change it.
+## Note that this may fail for login-restricted stories if the 
+## account used to login has 'Hide Additional Tags' enabled in OTW settings.
 include_in_genre: freeformtags, ao3categories
 
 ## OTW uses the word 'category' differently than most sites.  The

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -1581,6 +1581,8 @@ make_linkhtml_entries:series00,series01,series02,series03
 ## hardcoded to include the site specific metadata freeformtags &
 ## ao3categories in the standard metadata field genre.  By making it
 ## configurable, users can change it.
+## Note that this may fail for login-restricted stories if the 
+## account used has 'Hide Additional Tags' enabled in AO3 settings.
 include_in_genre: freeformtags, ao3categories
 
 ## AO3 uses the word 'category' differently than most sites.  The
@@ -2531,6 +2533,8 @@ make_linkhtml_entries:series00,series01,series02,series03
 ## hardcoded to include the site specific metadata freeformtags &
 ## ao3categories in the standard metadata field genre.  By making it
 ## configurable, users can change it.
+## Note that this may fail for login-restricted stories if the 
+## account used has 'Hide Additional Tags' enabled in OTW settings.
 include_in_genre: freeformtags, ao3categories
 
 ## OTW uses the word 'category' differently than most sites.  The

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -1582,7 +1582,7 @@ make_linkhtml_entries:series00,series01,series02,series03
 ## ao3categories in the standard metadata field genre.  By making it
 ## configurable, users can change it.
 ## Note that this may fail for login-restricted stories if the 
-## account used has 'Hide Additional Tags' enabled in AO3 settings.
+## account used to login has 'Hide Additional Tags' enabled in AO3 settings.
 include_in_genre: freeformtags, ao3categories
 
 ## AO3 uses the word 'category' differently than most sites.  The
@@ -2534,7 +2534,7 @@ make_linkhtml_entries:series00,series01,series02,series03
 ## ao3categories in the standard metadata field genre.  By making it
 ## configurable, users can change it.
 ## Note that this may fail for login-restricted stories if the 
-## account used has 'Hide Additional Tags' enabled in OTW settings.
+## account used to login has 'Hide Additional Tags' enabled in OTW settings.
 include_in_genre: freeformtags, ao3categories
 
 ## OTW uses the word 'category' differently than most sites.  The


### PR DESCRIPTION
Rather than add an FAQ entry for an infrequent issue, added a comment to the `include_in_genre` section for AO3/OTW.

```
## Note that this may fail for login-restricted stories if the 
## account used to login has 'Hide Additional Tags' enabled in [AO3|OTW] settings.
```

It may make sense to move the comment somewhere else, though.