### PR TITLE
Brief wording change for login warning

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -1504,8 +1504,8 @@ use_basic_cache:true
 #password:yourpassword
 
 ## Note that if 'Hide warnings' and/or 'Hide Additional Tags' are
-## enabled in the account settings, the AO3 adapter will not be able
-## to fetch them while logged-in.
+## enabled in the account settings, or you are using a site skin that hides them,
+## the AO3 adapter will not be able to fetch them while logged-in.
 
 ## In order to get bookmarktags and bookmarksummary, you need to login
 ## all the time.  This defaults to off to save time and network
@@ -2458,8 +2458,8 @@ extracategories:Buffy the Vampire Slayer
 #password:yourpassword
 
 ## Note that if 'Hide warnings' and/or 'Hide Additional Tags' are
-## enabled in the account settings, the OTW adapter will not be able
-## to fetch them while logged-in.
+## enabled in the account settings, or you are using a site skin that hides them,
+## the OTW adapter will not be able to fetch them while logged-in.
 
 ## In order to get bookmarktags and bookmarksummary, you need to login
 ## all the time.  This defaults to off to save time and network

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -1508,8 +1508,8 @@ use_basic_cache:true
 #password:yourpassword
 
 ## Note that if 'Hide warnings' and/or 'Hide Additional Tags' are
-## enabled in the account settings, the AO3 adapter will not be able
-## to fetch them while logged-in.
+## enabled in the account settings, or you are using a site skin that
+## hides them, the AO3 adapter will not be able to fetch them while logged-in.
 
 ## In order to get bookmarktags and bookmarksummary, you need to login
 ## all the time.  This defaults to off to save time and network
@@ -2462,8 +2462,8 @@ extracategories:Buffy the Vampire Slayer
 #password:yourpassword
 
 ## Note that if 'Hide warnings' and/or 'Hide Additional Tags' are
-## enabled in the account settings, the OTW adapter will not be able
-## to fetch them while logged-in.
+## enabled in the account settings, or you are using a site skin that hides them,
+## the OTW adapter will not be able to fetch them while logged-in.
 
 ## In order to get bookmarktags and bookmarksummary, you need to login
 ## all the time.  This defaults to off to save time and network


### PR DESCRIPTION
Since site skins can also possibly hide additional tags/warnings, I changed the comment to also account for those.