### PR TITLE
add ability to download AO3 workskin if scraping styles is enabled

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -1522,6 +1522,10 @@ use_basic_cache:true
 ## True by built-in default.
 #use_view_full_work:true
 
+## Some works on AO3 ship with an author-defined CSS sheet.
+## By default, do not include it.
+#use_workskin:false
+
 ## archiveofourown.org stories allow chapters to be added out of
 ## order.  So the newest chapter may not be the last one.  FanFicFare update
 ## doesn't like that.  If do_update_hook is uncommented and set true,

--- a/fanficfare/adapters/adapter_archiveofourownorg.py
+++ b/fanficfare/adapters/adapter_archiveofourownorg.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 import re
 import json
 
+from ..six import text_type as unicode
 from ..htmlcleanup import stripHTML
 from .. import exceptions as exceptions
 
@@ -398,13 +399,13 @@ class ArchiveOfOurOwnOrgAdapter(BaseSiteAdapter):
                     self.story.setMetadata('seriesUrl',series_url)
                     
                     
-        if 'style' in self.getConfigList('keep_html_attrs',[]):
+        if self.getConfig('use_workskin',False):
             divmain = metasoup.find('div',{'id':'main'})
             if divmain:
                 # we sort of assume ddmain exists because otherwise, there would be no fic
                 workskin = divmain.style
                 if workskin:
-                    workskin = str(workskin.contents[0])  # 'contents' returns a list with (here) a single element
+                    workskin = unicode(workskin.contents[0])  # 'contents' returns a list with (here) a single element
                     # some transformation to adjust which classes are affected
                     workskin = workskin.replace('#workskin', '.userstuff')
                     self.story.extra_css = "/*start of AO3 workskin*/\n" + workskin + "\n/* end of AO3 workskin*/\n"

--- a/fanficfare/adapters/adapter_archiveofourownorg.py
+++ b/fanficfare/adapters/adapter_archiveofourownorg.py
@@ -396,6 +396,18 @@ class ArchiveOfOurOwnOrgAdapter(BaseSiteAdapter):
                 if i == 0:
                     self.setSeries(series_name, series_index)
                     self.story.setMetadata('seriesUrl',series_url)
+                    
+                    
+        if 'style' in self.getConfigList('keep_html_attrs',[]):
+            divmain = metasoup.find('div',{'id':'main'})
+            if divmain:
+                # we sort of assume ddmain exists because otherwise, there would be no fic
+                workskin = divmain.style
+                if workskin:
+                    workskin = str(workskin.contents[0])  # 'contents' returns a list with (here) a single element
+                    # some transformation to adjust which classes are affected
+                    workskin = workskin.replace('#workskin', '.userstuff')
+                    self.story.extra_css = "/*start of AO3 workskin*/\n" + workskin + "\n/* end of AO3 workskin*/\n"
 
     def hookForUpdates(self,chaptercount):
         if self.newestChapterNum and self.oldchapters and len(self.oldchapters) > self.newestChapterNum:

--- a/fanficfare/configurable.py
+++ b/fanficfare/configurable.py
@@ -223,7 +223,8 @@ def get_valid_set_options():
                                   'archiveofourown.org'],None,boollist),
                'always_login':(['archiveofourown.org']+base_xenforo_list,None,boollist),
                'use_archived_author':(['archiveofourown.org'],None,boollist),
-               'use_view_full_work':(['archiveofourown.org'],None,boollist),
+               'use_view_full_work':(['archiveofourown.org','fanfics.me'],None,boollist),
+               'use_workskin':(['archiveofourown.org'],None,boollist),
                'remove_authorfootnotes_on_update':(['archiveofourown.org'],None,boollist),
 
                'non_breaking_spaces':(['fictionmania.tv'],None,boollist),
@@ -382,6 +383,7 @@ def get_valid_keywords():
                  'do_update_hook',
                  'use_archived_author',
                  'use_view_full_work',
+                 'use_workskin',
                  'always_login',
                  'exclude_notes',
                  'remove_authorfootnotes_on_update',

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -1526,6 +1526,10 @@ use_basic_cache:true
 ## True by built-in default.
 #use_view_full_work:true
 
+## Some works on AO3 ship with an author-defined CSS sheet.
+## By default, do not include it.
+#use_workskin:false
+
 ## archiveofourown.org stories allow chapters to be added out of
 ## order.  So the newest chapter may not be the last one.  FanFicFare update
 ## doesn't like that.  If do_update_hook is uncommented and set true,

--- a/fanficfare/story.py
+++ b/fanficfare/story.py
@@ -700,7 +700,7 @@ class Story(Requestable):
         self.chapter_text_replacements = []
         self.in_ex_cludes = {}
         self.chapters = [] # chapters will be dict containing(url,title,html,etc)
-        self.extra_css = ""
+        self.extra_css = ""  # story-wide author-defined CSS, like AO3's workskins
         self.chapter_first = None
         self.chapter_last = None
 

--- a/fanficfare/story.py
+++ b/fanficfare/story.py
@@ -700,6 +700,7 @@ class Story(Requestable):
         self.chapter_text_replacements = []
         self.in_ex_cludes = {}
         self.chapters = [] # chapters will be dict containing(url,title,html,etc)
+        self.extra_css = ""
         self.chapter_first = None
         self.chapter_last = None
 

--- a/fanficfare/writers/base_writer.py
+++ b/fanficfare/writers/base_writer.py
@@ -175,6 +175,7 @@ class BaseStoryWriter(Requestable):
             temp_css = self.getConfig("output_css")
         else:
             temp_css = ''
+        # if the story has author-defined CSS that we want to include, append it to FFF's existing CSS.
         if self.story.extra_css != '':
             if temp_css != '':
                 temp_css += '\n'

--- a/fanficfare/writers/base_writer.py
+++ b/fanficfare/writers/base_writer.py
@@ -172,8 +172,17 @@ class BaseStoryWriter(Requestable):
 
         # minor cheat, tucking css into metadata.
         if self.getConfig("output_css"):
+            temp_css = self.getConfig("output_css")
+        else:
+            temp_css = ''
+        if self.story.extra_css != '':
+            if temp_css != '':
+                temp_css += '\n'
+            temp_css += self.story.extra_css
+            
+        if temp_css:
             self.story.setMetadata("output_css",
-                                   self.getConfig("output_css"),
+                                   temp_css,
                                    condremoveentities=False)
         else:
             self.story.setMetadata("output_css",'')


### PR DESCRIPTION
If the "keep_html_attrs" config parameter includes "style", add the workskin (for AO3 works that have one) to the ebook's stylesheet.