### PR TITLE
Fix typos

### DIFF
--- a/calibre-plugin/__init__.py
+++ b/calibre-plugin/__init__.py
@@ -124,7 +124,7 @@ class FanFicFareBase(InterfaceActionBase):
 
         with self: # so the sys.path was modified appropriately
             # I believe there's no performance hit loading these here when
-            # CLI--it would load everytime anyway.
+            # CLI--it would load every time anyway.
             from calibre.library import db
             from fanficfare.cli import main as fff_main
             from calibre_plugins.fanficfare_plugin.prefs import PrefsFacade

--- a/calibre-plugin/config.py
+++ b/calibre-plugin/config.py
@@ -101,7 +101,7 @@ class RejectURLList:
     ## adapters.get_section_url(url) to all urls before caching and
     ## before checking so ffnet/a/123/1/Title -> ffnet/a/123/1/,
     ## xenforo too.  Saved list still contains full URL so we're not
-    ## destorying any data.  Could have duplicates, though.
+    ## destroying any data.  Could have duplicates, though.
     def _get_listcache(self):
         with busy_cursor():
             if self.listcache == None:
@@ -511,7 +511,7 @@ class BasicTab(QWidget):
         self.l.addWidget(self.checkforseriesurlid)
 
         self.auto_reject_seriesurlid = QCheckBox(_("Reject Without Confirmation?"),self)
-        self.auto_reject_seriesurlid.setToolTip(_("Automatically reject storys with existing Series Anthology books.\nOnly works if 'Check for existing Series Anthology books' is on.\nDoesn't work when Collect Metadata in Background is selected."))
+        self.auto_reject_seriesurlid.setToolTip(_("Automatically reject stories with existing Series Anthology books.\nOnly works if 'Check for existing Series Anthology books' is on.\nDoesn't work when Collect Metadata in Background is selected."))
         self.auto_reject_seriesurlid.setChecked(prefs['auto_reject_seriesurlid'])
         self.auto_reject_seriesurlid.setEnabled(self.checkforseriesurlid.isChecked())
 

--- a/calibre-plugin/dialogs.py
+++ b/calibre-plugin/dialogs.py
@@ -1474,7 +1474,7 @@ class IniTextDialog(SizePersistedDialog):
             end = self.lastStart + len(query)
             self.moveCursor(self.lastStart,end)
         else:
-            # Make the next search start from the begining again
+            # Make the next search start from the beginning again
             self.lastStart = 0
             self.textedit.moveCursor(MoveOperations.Start)
 

--- a/calibre-plugin/fff_plugin.py
+++ b/calibre-plugin/fff_plugin.py
@@ -1128,7 +1128,7 @@ class FanFicFarePlugin(InterfaceAction):
 
         #print("prep_downloads:%s"%books)
 
-        if 'tdir' not in options: # if merging an anthology, there's alread a tdir.
+        if 'tdir' not in options: # if merging an anthology, there's already a tdir.
             # create and pass temp dir.
             tdir = PersistentTemporaryDirectory(prefix='fanficfare_')
             options['tdir']=tdir
@@ -2940,7 +2940,7 @@ The previously downloaded book is still in the anthology, but FFF doesn't have t
                             book['all_metadata'][k]=book['all_metadata'][k]+"\n\n"+v
                         else:
                             book['all_metadata'][k]=book['all_metadata'][k]+", "+v
-                            # flag psuedo list element.  Used so numeric
+                            # flag pseudo list element.  Used so numeric
                             # cust cols can convert back to numbers and
                             # add.
                             book['anthology_meta_list'][k]=True

--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -358,12 +358,12 @@ conditionals_use_lists:true
 
 ## 'r_anthaver' and 'n_anthaver' can be used to indicate the same as
 ## 'r' and 'n' for normal downloads, but to average the metadata for
-## the differents story in an anthology before setting in integer and
+## the different story in an anthology before setting in integer and
 ## float type custom columns.  This can be useful for a averrating
 ## column, for example.
 ## 'r_anthmax' and 'n_anthmax' indicate 'r' and 'n' for normal
 ## downloads, but to use the highest value for the metadata from the
-## differents story in an anthology in integer and float type custom
+## different story in an anthology in integer and float type custom
 ## columns.
 ## Default is to sum the values of all stories, and numChapters and
 ## numWords are always summed.
@@ -983,7 +983,7 @@ use_threadmark_wordcounts:true
 #tocpage_entry:
 # <a href="file${index04}.xhtml">${chapter}</a> ${date} ${kwords}<br /><br />
 
-## The 'date' value for chapters mentioned above can be formated with
+## The 'date' value for chapters mentioned above can be formatted with
 ## datethreadmark_format.  Otherwise it will default to
 ## dateCreated_format
 #datethreadmark_format:%%Y-%%m-%%d %%H:%%M
@@ -1669,7 +1669,7 @@ slow_down_sleep_time:2
 #tocpage_entry:
 # <a href="file${index04}.xhtml">${chapter}</a> ${date}<br /><br />
 
-## The 'date' value for chapters mentioned above can be formated with
+## The 'date' value for chapters mentioned above can be formatted with
 ## datechapter_format.  Otherwise it will default to
 ## datePublished_format
 #datechapter_format:%%Y-%%m-%%d
@@ -1918,7 +1918,7 @@ add_to_output_css:
 
 ## fiction.live spoilers display as a (blank) block until clicked, then they can become inline text.
 ## with true, adds them to an outlined block marked as a spoiler.
-## with false, the text of the spoiler is unmarked and present in the work, as though alreday clicked
+## with false, the text of the spoiler is unmarked and present in the work, as though already clicked
 #legend_spoilers:true
 ## display 'spoiler' tags in the tag list, which can contain plot details
 #show_spoiler_tags:false
@@ -2614,7 +2614,7 @@ slow_down_sleep_time:2
 #tocpage_entry:
 # <a href="file${index04}.xhtml">${chapter}</a> ${date}<br /><br />
 
-## The 'date' value for chapters mentioned above can be formated with
+## The 'date' value for chapters mentioned above can be formatted with
 ## datechapter_format.  Otherwise it will default to
 ## datePublished_format
 #datechapter_format:%%Y-%%m-%%d
@@ -2817,7 +2817,7 @@ extracategories:Star Trek
 ## adult content.  Uncomment by removing '#' in front of is_adult.
 #is_adult:true
 
-## This site has links to a vidow site embeded in the text. They are
+## This site has links to a vidow site embedded in the text. They are
 ## not needed, and will be removed if the below property is set to true
 strip_text_links:true
 
@@ -3059,7 +3059,7 @@ extra_valid_entries:house,era,spoilers,hits
 #tocpage_entry:
 # <a href="file${index04}.xhtml">${chapter}</a> ${date} ${words}<br /><br />
 
-## The 'date' value for chapters mentioned above can be formated with
+## The 'date' value for chapters mentioned above can be formatted with
 ## datechapter_format.  Otherwise it will default to
 ## datePublished_format
 #datechapter_format:%%Y-%%m-%%d
@@ -3256,7 +3256,7 @@ vote_rating_label:Votes(Rating)
 # <a href="file${index04}.xhtml">${chapter}</a> ${date} ${size}<br /><br />
 
 ## The 'date' and 'update' value for chapters mentioned above can be
-## formated with datechapter_format.  Otherwise it will default to
+## formatted with datechapter_format.  Otherwise it will default to
 ## datePublished_format
 #datechapter_format:%%Y-%%m-%%d
 

--- a/calibre-plugin/wordcount.py
+++ b/calibre-plugin/wordcount.py
@@ -87,7 +87,7 @@ def _read_epub_contents(iterator, strip_html=False):
 
 def _extract_body_text(data):
     '''
-    Get the body text of this html content wit any html tags stripped
+    Get the body text of this html content with any html tags stripped
     '''
     body = RE_HTML_BODY.findall(data)
     if body:

--- a/fanficfare/adapters/adapter_adultfanfictionorg.py
+++ b/fanficfare/adapters/adapter_adultfanfictionorg.py
@@ -231,7 +231,7 @@ class AdultFanFictionOrgAdapter(BaseSiteAdapter):
             self.story.setMetadata('authorId','000000000')
             self.story.setMetadata('authorUrl','https://www.adult-fanfiction.org')
             self.story.setMetadata('author','Unknown')
-            logger.warning('There was no author found for the story... Metadata will not be retreived.')
+            logger.warning('There was no author found for the story... Metadata will not be retrieved.')
             self.setDescription(url,'>>>>>>>>>> No Summary Given <<<<<<<<<<')
         else:
             self.story.setMetadata('authorId',a['href'].split('=')[1])
@@ -306,7 +306,7 @@ class AdultFanFictionOrgAdapter(BaseSiteAdapter):
 
             ##Split the Metadata up into a list
             ##We have to change the soup type to a string, then remove the newlines, and double spaces,
-            ##then changes the <br/> to '-:-', which seperates the different elemeents.
+            ##then changes the <br/> to '-:-', which separates the different elemeents.
             ##Then we strip the HTML elements from the string.
             ##There is also a double <br/>, so we have to fix that, then remove the leading and trailing '-:-'.
             ##They are always in the same order.

--- a/fanficfare/adapters/adapter_asexstoriescom.py
+++ b/fanficfare/adapters/adapter_asexstoriescom.py
@@ -143,7 +143,7 @@ class ASexStoriesComAdapter(BaseSiteAdapter):
         # get story text
         story1 = soup1.find('div', {'class':'story-block'})
         
-        ### This site has links embeded in the text that lead 
+        ### This site has links embedded in the text that lead 
         ### to either a video site, or to a tags index page
         ### the default is to remove them, but you can set the 
         ### strip_text_links to false to keep them in the text

--- a/fanficfare/adapters/adapter_ashwindersycophanthexcom.py
+++ b/fanficfare/adapters/adapter_ashwindersycophanthexcom.py
@@ -120,8 +120,8 @@ class AshwinderSycophantHexComAdapter(BaseSiteAdapter):
             self.performLogin(url)
             data = self.get_request(url)
 
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+        if "Access denied. This story has not been validated by the administrators of this site." in data:
+            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the administrators of this site.")
 
         soup = self.make_soup(data)
         # print data
@@ -161,7 +161,7 @@ class AshwinderSycophantHexComAdapter(BaseSiteAdapter):
 
 
         # eFiction sites don't help us out a lot with their meta data
-        # formating, so it's a little ugly.
+        # formatting, so it's a little ugly.
 
         # utility method
         def defaultGetattr(d):

--- a/fanficfare/adapters/adapter_asianfanficscom.py
+++ b/fanficfare/adapters/adapter_asianfanficscom.py
@@ -194,7 +194,7 @@ class AsianFanFicsComAdapter(BaseSiteAdapter):
             content = self.make_soup(fore_json['post']).find('body') # BS4 adds <html><body> if not present.
             a = content.find('div', {'id':'story-description'})
         except:
-            # not all stories have foreward link.
+            # not all stories have foreword link.
             a = soup.find('div', {'id':'story-description'})
         if a:
             self.setDescription(url,a)

--- a/fanficfare/adapters/adapter_bdsmlibrarycom.py
+++ b/fanficfare/adapters/adapter_bdsmlibrarycom.py
@@ -31,7 +31,7 @@ probably need to be edited for reading.
 I've seen one story that downloaded at 25M, but after editing is only 201K
 after the formatting was corrected.
 
-Right now it is written to download each chapter seperatly, but I may change
+Right now it is written to download each chapter separately, but I may change
 that to get the whole story. It will still have formatting problems, but should
 be able to get the longer stories this way.
 

--- a/fanficfare/adapters/adapter_chaossycophanthexcom.py
+++ b/fanficfare/adapters/adapter_chaossycophanthexcom.py
@@ -94,8 +94,8 @@ class ChaosSycophantHexComAdapter(BaseSiteAdapter):
         if "Age Consent Required" in data:
             raise exceptions.AdultCheckRequired(self.url)
 
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+        if "Access denied. This story has not been validated by the administrators of this site." in data:
+            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the administrators of this site.")
 
         soup = self.make_soup(data)
         # print data
@@ -122,7 +122,7 @@ class ChaosSycophantHexComAdapter(BaseSiteAdapter):
 
 
         # eFiction sites don't help us out a lot with their meta data
-        # formating, so it's a little ugly.
+        # formatting, so it's a little ugly.
 
         # utility method
         def defaultGetattr(d,k):

--- a/fanficfare/adapters/adapter_chosentwofanficcom.py
+++ b/fanficfare/adapters/adapter_chosentwofanficcom.py
@@ -89,8 +89,8 @@ class ChosenTwoFanFicArchiveAdapter(BaseSiteAdapter):
         if "Content is only suitable for mature adults. May contain explicit language and adult themes. Equivalent of NC-17." in data:
             raise exceptions.AdultCheckRequired(self.url)
 
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied("{0} says: Access denied. This story has not been validated by the adminstrators of this site.".format(self.getSiteDomain()))
+        if "Access denied. This story has not been validated by the administrators of this site." in data:
+            raise exceptions.AccessDenied("{0} says: Access denied. This story has not been validated by the administrators of this site.".format(self.getSiteDomain()))
 
         soup = self.make_soup(data)
 
@@ -117,7 +117,7 @@ class ChosenTwoFanFicArchiveAdapter(BaseSiteAdapter):
 
 
         # eFiction sites don't help us out a lot with their meta data
-        # formating, so it's a little ugly.
+        # formatting, so it's a little ugly.
 
         # utility method
         def defaultGetattr(d,k):

--- a/fanficfare/adapters/adapter_dokugacom.py
+++ b/fanficfare/adapters/adapter_dokugacom.py
@@ -133,8 +133,8 @@ class DokugaComAdapter(BaseSiteAdapter):
             data = self.get_request(url)
             soup = self.make_soup(data)
 
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+        if "Access denied. This story has not been validated by the administrators of this site." in data:
+            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the administrators of this site.")
         # print data
 
 

--- a/fanficfare/adapters/adapter_dracoandginnycom.py
+++ b/fanficfare/adapters/adapter_dracoandginnycom.py
@@ -143,8 +143,8 @@ class DracoAndGinnyComAdapter(BaseSiteAdapter):
             else:
                 raise exceptions.AdultCheckRequired(self.url)
 
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+        if "Access denied. This story has not been validated by the administrators of this site." in data:
+            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the administrators of this site.")
 
         soup = self.make_soup(data)
         # print data
@@ -167,7 +167,7 @@ class DracoAndGinnyComAdapter(BaseSiteAdapter):
 
 
         # eFiction sites don't help us out a lot with their meta data
-        # formating, so it's a little ugly.
+        # formatting, so it's a little ugly.
 
         # utility method
         def defaultGetattr(d,k):

--- a/fanficfare/adapters/adapter_efpfanficnet.py
+++ b/fanficfare/adapters/adapter_efpfanficnet.py
@@ -114,8 +114,8 @@ class EFPFanFicNet(BaseSiteAdapter):
             self.performLogin(url)
             data = self.get_request(url)
 
-        # if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-        #     raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+        # if "Access denied. This story has not been validated by the administrators of this site." in data:
+        #     raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the administrators of this site.")
 
         soup = self.make_soup(data)
         # print data
@@ -156,7 +156,7 @@ class EFPFanFicNet(BaseSiteAdapter):
 
 
         # eFiction sites don't help us out a lot with their meta data
-        # formating, so it's a little ugly.
+        # formatting, so it's a little ugly.
 
         storya = None
         authsoup = None

--- a/fanficfare/adapters/adapter_erosnsapphosycophanthexcom.py
+++ b/fanficfare/adapters/adapter_erosnsapphosycophanthexcom.py
@@ -104,8 +104,8 @@ class ErosnSapphoSycophantHexComAdapter(BaseSiteAdapter):
             else:
                 raise exceptions.AdultCheckRequired(self.url)
 
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+        if "Access denied. This story has not been validated by the administrators of this site." in data:
+            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the administrators of this site.")
 
         soup = self.make_soup(data)
         # print data
@@ -132,7 +132,7 @@ class ErosnSapphoSycophantHexComAdapter(BaseSiteAdapter):
 
 
         # eFiction sites don't help us out a lot with their meta data
-        # formating, so it's a little ugly.
+        # formatting, so it's a little ugly.
 
         # utility method
         def defaultGetattr(d,k):

--- a/fanficfare/adapters/adapter_fanfictalkcom.py
+++ b/fanficfare/adapters/adapter_fanfictalkcom.py
@@ -61,7 +61,7 @@ class FanfictalkComAdapter(BaseSiteAdapter):
 
     @classmethod
     def getConfigSections(cls):
-        "Only needs to be overriden if has additional ini sections."
+        "Only needs to be overridden if has additional ini sections."
         return [cls.getConfigSection(),'archive.hpfanfictalk.com']
 
     @staticmethod # must be @staticmethod, don't remove it.
@@ -95,8 +95,8 @@ class FanfictalkComAdapter(BaseSiteAdapter):
 
         data = self.get_request(url)
 
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+        if "Access denied. This story has not been validated by the administrators of this site." in data:
+            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the administrators of this site.")
 
         ## Title and author
         soup = self.make_soup(data)

--- a/fanficfare/adapters/adapter_fastnovelsnet.py
+++ b/fanficfare/adapters/adapter_fastnovelsnet.py
@@ -64,7 +64,7 @@ class FastNovelNetAdapter(BaseSiteAdapter):
 
     @classmethod
     def getConfigSections(cls):
-        "Only needs to be overriden if has additional ini sections."
+        "Only needs to be overridden if has additional ini sections."
         return [cls.getConfigSection(),'fastnovel.net']
 
     @classmethod

--- a/fanficfare/adapters/adapter_fictionlive.py
+++ b/fanficfare/adapters/adapter_fictionlive.py
@@ -24,7 +24,7 @@
 
 ### can't support because wtf this is a book
 # music / audio embeds
-# per-user achivement tracking with fancy achievement-get animations
+# per-user achievement tracking with fancy achievement-get animations
 # story scripting (shows script tags visible in the text, not computed values or input fields)
 
 import re
@@ -240,7 +240,7 @@ class FictionLiveAdapter(BaseSiteAdapter):
             next(b, None)
             return list(zip(a, b))
 
-        ## first thing to do is seperate out the appendices
+        ## first thing to do is separate out the appendices
         appendices, maintext, routes = [], [], []
         chapters = data['bm'] if 'bm' in data else []
 
@@ -353,14 +353,14 @@ class FictionLiveAdapter(BaseSiteAdapter):
     def fictionlive_normalize(self, string):
         # might be able to use this to preserve titles in normalized urls, if the scheme is the same
 
-        # BUG: in achivement ids these are all replaced, but I *don't* know that the list is complete.
+        # BUG: in achievement ids these are all replaced, but I *don't* know that the list is complete.
         # should be rare, thankfully. *most* authors don't use any funny characters in the achievment's *ID*
         special_chars = "\"\\,.!?+=/[](){}<>_'@#$%^&*~`;:|" # not the hyphen, which is used to represent spaces
 
         return string.lower().replace(" ", "-").translate({ord(x) : None for x in special_chars})
 
     def append_achievments(self, soup):
-        # achivements are present in the text as a kind of link, and you get the shiny popup by clicking them.
+        # achievements are present in the text as a kind of link, and you get the shiny popup by clicking them.
         achievement_links = soup.find_all('a', class_="tydai-achievement")
 
         achieved_ids = []
@@ -369,11 +369,11 @@ class FictionLiveAdapter(BaseSiteAdapter):
             # should use .u css selector -- part of output_css defaults? or just let replace_tags_with_spans do it?
             new_u = soup.new_tag('u')
             new_u.string = link_tag.text # copy out the link text into a new element
-            # html entities for improved compatability with AZW3 conversion
+            # html entities for improved compatibility with AZW3 conversion
             link_tag.string = "&#x26A1;" # then overwrite
             link_tag.insert(1, new_u)
 
-            ## while we've got the achievment links, get the ids from the link
+            ## while we've got the achievement links, get the ids from the link
             a_id = link_tag['data-id']
             a_id = self.fictionlive_normalize(a_id)
 
@@ -393,7 +393,7 @@ class FictionLiveAdapter(BaseSiteAdapter):
                 soup.append(self.make_soup(a_source.format(a_title, a_text)))
             else:
                 a_title = a_id.title()
-                error = "<br />\n<fieldset><legend>Error: Achievement not found.</legend>Couldn't find '{}'. Ask the story author to check if the achievment exists."
+                error = "<br />\n<fieldset><legend>Error: Achievement not found.</legend>Couldn't find '{}'. Ask the story author to check if the achievement exists."
                 soup.append(self.make_soup(error.format(a_title)))
 
         return soup
@@ -506,7 +506,7 @@ class FictionLiveAdapter(BaseSiteAdapter):
         output += u"<h4><span>Reader Posts — <small> Posting " + closed
         output += u" — " + num_votes + "</small></span></h4>\n"
 
-        ## so. a voter can roll with their post. these rolls are in a seperate dict, but have the **same uid**.
+        ## so. a voter can roll with their post. these rolls are in a separate dict, but have the **same uid**.
         ## they're then formatted with the roll above the writein for that user.
         ## I *think* that formatting roll-only before writein-only posts is correct, but tbh, it's hard to tell.
         ## writeins are usually opened by the author for posts or rolls, not both at once.
@@ -532,7 +532,7 @@ class FictionLiveAdapter(BaseSiteAdapter):
     def format_unknown(self, chunk):
         raise NotImplementedError("Unknown chunk type ({}) in fiction.live story.".format(chunk))
 
-# in future, I'd like to handle audio embeds somehow. but they're not availble to add to stories right now.
+# in future, I'd like to handle audio embeds somehow. but they're not available to add to stories right now.
 # pretty sure they'll just format as a link (with a special tydai-audio class) and should be easier than achievements
 
 # TODO: verify that show_timestamps is working, check times!

--- a/fanficfare/adapters/adapter_fireflyfansnet.py
+++ b/fanficfare/adapters/adapter_fireflyfansnet.py
@@ -113,7 +113,7 @@ class FireFlyFansNetSiteAdapter(BaseSiteAdapter):
         else:
             self.setDescription(url, summary)
 
-        # There is not alot of Metadata with this site, so we get what we can.
+        # There is not a lot of Metadata with this site, so we get what we can.
         pubdate = soup.find('span', {'id': 'MainContent_txtItemInfo'})
         pubdate = stripHTML(pubdate)
         pubdate = pubdate[pubdate.find(', ') + 1:]
@@ -121,7 +121,7 @@ class FireFlyFansNetSiteAdapter(BaseSiteAdapter):
             pubdate.strip(), self.dateformat))
 
         # The only Metadata that I can find is the Category (usually Fiction) and the series
-        # which is usualy FireFly on this site, but I'm going to get them
+        # which is usually FireFly on this site, but I'm going to get them
         # anyway.a
         category = soup.find('span', {'id': 'MainContent_txtItemDetails'})
         category = stripHTML(unicode(category).replace(u"\xa0", u' '))

--- a/fanficfare/adapters/adapter_imagineeficcom.py
+++ b/fanficfare/adapters/adapter_imagineeficcom.py
@@ -143,8 +143,8 @@ class ImagineEFicComAdapter(BaseSiteAdapter):
             else:
                 raise exceptions.AdultCheckRequired(self.url)
 
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+        if "Access denied. This story has not been validated by the administrators of this site." in data:
+            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the administrators of this site.")
 
         soup = self.make_soup(data)
         # print data
@@ -167,7 +167,7 @@ class ImagineEFicComAdapter(BaseSiteAdapter):
 
 
         # eFiction sites don't help us out a lot with their meta data
-        # formating, so it's a little ugly.
+        # formatting, so it's a little ugly.
 
         # utility method
         def defaultGetattr(d,k):

--- a/fanficfare/adapters/adapter_ksarchivecom.py
+++ b/fanficfare/adapters/adapter_ksarchivecom.py
@@ -130,8 +130,8 @@ class KSArchiveComAdapter(BaseSiteAdapter): # XXX
             else:
                 raise exceptions.AdultCheckRequired(self.url)
 
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+        if "Access denied. This story has not been validated by the administrators of this site." in data:
+            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the administrators of this site.")
 
         soup = self.make_soup(data)
         # print data
@@ -156,7 +156,7 @@ class KSArchiveComAdapter(BaseSiteAdapter): # XXX
 
 
         # eFiction sites don't help us out a lot with their meta data
-        # formating, so it's a little ugly.
+        # formatting, so it's a little ugly.
 
         # utility method
         def defaultGetattr(d,k):

--- a/fanficfare/adapters/adapter_lcfanficcom.py
+++ b/fanficfare/adapters/adapter_lcfanficcom.py
@@ -151,8 +151,8 @@ class LCFanFicComSiteAdapter(BaseSiteAdapter):
         self.story.setMetadata('datePublished', makeDate(datetime.datetime.now().strftime ("%Y-%m-%d"), "%Y-%m-%d"))
         self.story.setMetadata('dateUpdated', makeDate(datetime.datetime.now().strftime ("%Y-%m-%d"), "%Y-%m-%d"))
 
-        ## This is a 1 story/page site, so we'll keep the soup fo the getChapterText function
-        ## the chapterUrl nd numChapters need to be set as well
+        ## This is a 1 story/page site, so we'll keep the soup for the getChapterText function
+        ## the chapterUrl and numChapters need to be set as well
         self.html = data
         self.add_chapter(self.story.getMetadata('title'),url)
 

--- a/fanficfare/adapters/adapter_lumossycophanthexcom.py
+++ b/fanficfare/adapters/adapter_lumossycophanthexcom.py
@@ -94,8 +94,8 @@ class LumosSycophantHexComAdapter(BaseSiteAdapter):
         if "Age Consent Required" in data:
             raise exceptions.AdultCheckRequired(self.url)
 
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+        if "Access denied. This story has not been validated by the administrators of this site." in data:
+            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the administrators of this site.")
 
         soup = self.make_soup(data)
         # print data
@@ -122,7 +122,7 @@ class LumosSycophantHexComAdapter(BaseSiteAdapter):
 
 
         # eFiction sites don't help us out a lot with their meta data
-        # formating, so it's a little ugly.
+        # formatting, so it's a little ugly.
 
         # utility method
         def defaultGetattr(d,k):

--- a/fanficfare/adapters/adapter_midnightwhispers.py
+++ b/fanficfare/adapters/adapter_midnightwhispers.py
@@ -72,7 +72,7 @@ class MidnightwhispersAdapter(BaseSiteAdapter): # XXX
 
     @classmethod
     def getConfigSections(cls):
-        "Only needs to be overriden if has additional ini sections."
+        "Only needs to be overridden if has additional ini sections."
         return ['www.midnightwhispers.ca',cls.getSiteDomain()]
 
     @classmethod
@@ -135,8 +135,8 @@ class MidnightwhispersAdapter(BaseSiteAdapter): # XXX
             else:
                 raise exceptions.AdultCheckRequired(self.url)
 
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+        if "Access denied. This story has not been validated by the administrators of this site." in data:
+            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the administrators of this site.")
 
         soup = self.make_soup(data)
         # print data
@@ -160,7 +160,7 @@ class MidnightwhispersAdapter(BaseSiteAdapter): # XXX
 
 
         # eFiction sites don't help us out a lot with their meta data
-        # formating, so it's a little ugly.
+        # formatting, so it's a little ugly.
 
         # utility method
         def defaultGetattr(d,k):

--- a/fanficfare/adapters/adapter_ninelivesarchivecom.py
+++ b/fanficfare/adapters/adapter_ninelivesarchivecom.py
@@ -40,7 +40,7 @@ class NineLivesAdapter(BaseEfictionAdapter):
 
     @classmethod
     def getConfigSections(cls):
-        "Only needs to be overriden if has additional ini sections."
+        "Only needs to be overridden if has additional ini sections."
         return ['base_efiction','ninelives.dark-solace.org',cls.getSiteDomain()]
 
     @classmethod

--- a/fanficfare/adapters/adapter_novelonlinefullcom.py
+++ b/fanficfare/adapters/adapter_novelonlinefullcom.py
@@ -84,7 +84,7 @@ class LightNovelGateSiteAdapter(BaseSiteAdapter):
 
     @classmethod
     def getConfigSections(cls):
-        "Only needs to be overriden if has additional ini sections."
+        "Only needs to be overridden if has additional ini sections."
         return ['lightnovelgate.com',cls.getSiteDomain()]
 
     @classmethod

--- a/fanficfare/adapters/adapter_occlumencysycophanthexcom.py
+++ b/fanficfare/adapters/adapter_occlumencysycophanthexcom.py
@@ -120,8 +120,8 @@ class OcclumencySycophantHexComAdapter(BaseSiteAdapter):
             self.performLogin(url)
             data = self.get_request(url)
 
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+        if "Access denied. This story has not been validated by the administrators of this site." in data:
+            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the administrators of this site.")
 
         soup = self.make_soup(data)
         # print data
@@ -162,7 +162,7 @@ class OcclumencySycophantHexComAdapter(BaseSiteAdapter):
 
 
         # eFiction sites don't help us out a lot with their meta data
-        # formating, so it's a little ugly.
+        # formatting, so it's a little ugly.
 
         # utility method
         def defaultGetattr(d):

--- a/fanficfare/adapters/adapter_ponyfictionarchivenet.py
+++ b/fanficfare/adapters/adapter_ponyfictionarchivenet.py
@@ -108,8 +108,8 @@ class PonyFictionArchiveNetAdapter(BaseSiteAdapter):
             else:
                 raise exceptions.AdultCheckRequired(self.url)
 
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+        if "Access denied. This story has not been validated by the administrators of this site." in data:
+            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the administrators of this site.")
 
         soup = self.make_soup(data)
         # print data
@@ -132,7 +132,7 @@ class PonyFictionArchiveNetAdapter(BaseSiteAdapter):
 
 
         # eFiction sites don't help us out a lot with their meta data
-        # formating, so it's a little ugly.
+        # formatting, so it's a little ugly.
 
         # utility method
         def defaultGetattr(d,k):

--- a/fanficfare/adapters/adapter_potionsandsnitches.py
+++ b/fanficfare/adapters/adapter_potionsandsnitches.py
@@ -64,8 +64,8 @@ class PotionsAndSnitchesOrgSiteAdapter(BaseSiteAdapter):
 
         data = self.get_request(url)
 
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+        if "Access denied. This story has not been validated by the administrators of this site." in data:
+            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the administrators of this site.")
 
         soup = self.make_soup(data)
 

--- a/fanficfare/adapters/adapter_pretendercentrecom.py
+++ b/fanficfare/adapters/adapter_pretendercentrecom.py
@@ -103,8 +103,8 @@ class PretenderCenterComAdapter(BaseSiteAdapter):
             else:
                 raise exceptions.AdultCheckRequired(self.url)
 
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+        if "Access denied. This story has not been validated by the administrators of this site." in data:
+            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the administrators of this site.")
 
         soup = self.make_soup(data)
         # print data
@@ -127,7 +127,7 @@ class PretenderCenterComAdapter(BaseSiteAdapter):
 
 
         # eFiction sites don't help us out a lot with their meta data
-        # formating, so it's a little ugly.
+        # formatting, so it's a little ugly.
 
         # utility method
         def defaultGetattr(d,k):

--- a/fanficfare/adapters/adapter_psychficcom.py
+++ b/fanficfare/adapters/adapter_psychficcom.py
@@ -93,8 +93,8 @@ class PsychFicComAdapter(BaseSiteAdapter):
         if "By clicking this link, you acknowledge" in data:
             raise exceptions.AdultCheckRequired(self.url)
 
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+        if "Access denied. This story has not been validated by the administrators of this site." in data:
+            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the administrators of this site.")
 
         soup = self.make_soup(data)
         # print data
@@ -117,7 +117,7 @@ class PsychFicComAdapter(BaseSiteAdapter):
 
 
         # eFiction sites don't help us out a lot with their meta data
-        # formating, so it's a little ugly.
+        # formatting, so it's a little ugly.
 
         # utility method
         def defaultGetattr(d,k):

--- a/fanficfare/adapters/adapter_royalroadcom.py
+++ b/fanficfare/adapters/adapter_royalroadcom.py
@@ -83,7 +83,7 @@ class RoyalRoadAdapter(BaseSiteAdapter):
 
     @classmethod
     def getConfigSections(cls):
-        "Only needs to be overriden if has additional ini sections."
+        "Only needs to be overridden if has additional ini sections."
         return ['royalroadl.com',cls.getSiteDomain()]
 
     @classmethod
@@ -262,7 +262,7 @@ class RoyalRoadAdapter(BaseSiteAdapter):
 
         div = soup.find('div',{'class':"chapter-inner chapter-content"})
 
-        # TODO: these stories often have tables in, but these wont render correctly
+        # TODO: these stories often have tables in, but these won't render correctly
         # defaults.ini output CSS now outlines/pads the tables, at least.
 
         if None == div:

--- a/fanficfare/adapters/adapter_samandjacknet.py
+++ b/fanficfare/adapters/adapter_samandjacknet.py
@@ -179,8 +179,8 @@ class SamAndJackNetAdapter(BaseSiteAdapter): # XXX
             else:
                 raise exceptions.AdultCheckRequired(self.url)
 
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+        if "Access denied. This story has not been validated by the administrators of this site." in data:
+            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the administrators of this site.")
 
         soup = self.make_soup(data)
         # print data
@@ -211,7 +211,7 @@ class SamAndJackNetAdapter(BaseSiteAdapter): # XXX
 
 
         # eFiction sites don't help us out a lot with their meta data
-        # formating, so it's a little ugly.
+        # formatting, so it's a little ugly.
 
         # utility method
         def defaultGetattr(d,k):

--- a/fanficfare/adapters/adapter_scribblehubcom.py
+++ b/fanficfare/adapters/adapter_scribblehubcom.py
@@ -176,7 +176,7 @@ class ScribbleHubComAdapter(BaseSiteAdapter): # XXX
 
 
         # eFiction sites don't help us out a lot with their meta data
-        # formating, so it's a little ugly.
+        # formatting, so it's a little ugly.
 
         # utility method
         def defaultGetattr(d,k):
@@ -225,7 +225,7 @@ class ScribbleHubComAdapter(BaseSiteAdapter): # XXX
 
 
         # Updated | looks like this: <span title="Last updated: Jul 16, 2020 01:02 AM">Jul 16, 2020</span> -- snip out the date
-        # if we can't parse the date it's because it's today and it says somehting like "6 hours ago"
+        # if we can't parse the date it's because it's today and it says something like "6 hours ago"
         if stripHTML(soup.find_all("span", title=re.compile(r"^Last"))[0]):
             date_str = soup.find_all("span", title=re.compile(r"^Last"))[0].get("title")
             try:
@@ -243,7 +243,7 @@ class ScribbleHubComAdapter(BaseSiteAdapter): # XXX
         try:
             self.story.setMetadata('datePublished', makeDate(stripHTML(soup.find('span', {'class': 'fic_date_pub'})), self.dateformat))
         except ValueError:
-            # if we get a ValueError it's because it's today and it says somehting like "6 hours ago"
+            # if we get a ValueError it's because it's today and it says something like "6 hours ago"
             self.story.setMetadata('datePublished', datetime.datetime.now())
 
         # Ratings, default to not rated. Scribble hub has no rating system, but has genres for mature and adult, so try to set to these

--- a/fanficfare/adapters/adapter_sheppardweircom.py
+++ b/fanficfare/adapters/adapter_sheppardweircom.py
@@ -157,8 +157,8 @@ class SheppardWeirComAdapter(BaseSiteAdapter): # XXX
         if "Age Consent Required" in data: # XXX
             raise exceptions.AdultCheckRequired(self.url)
 
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+        if "Access denied. This story has not been validated by the administrators of this site." in data:
+            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the administrators of this site.")
 
         soup = self.make_soup(data)
         # print data
@@ -191,7 +191,7 @@ class SheppardWeirComAdapter(BaseSiteAdapter): # XXX
 
 
         # eFiction sites don't help us out a lot with their meta data
-        # formating, so it's a little ugly.
+        # formatting, so it's a little ugly.
 
         # utility method
         def defaultGetattr(d,k):

--- a/fanficfare/adapters/adapter_sinfuldreamscomunicornfic.py
+++ b/fanficfare/adapters/adapter_sinfuldreamscomunicornfic.py
@@ -31,7 +31,7 @@ class SinfulDreamsComUnicornFic(BaseEfictionAdapter):
 
     @classmethod
     def getConfigSection(cls):
-        "Overriden because [domain/path] section for multiple-adapter domain."
+        "Overridden because [domain/path] section for multiple-adapter domain."
         return cls.getSiteDomain()+cls.getPathToArchive()
 
     @classmethod

--- a/fanficfare/adapters/adapter_sinfuldreamscomwhisperedmuse.py
+++ b/fanficfare/adapters/adapter_sinfuldreamscomwhisperedmuse.py
@@ -31,7 +31,7 @@ class SinfulDreamsComWhisperedMuse(BaseEfictionAdapter):
 
     @classmethod
     def getConfigSection(cls):
-        "Overriden because [domain/path] section for multiple-adapter domain."
+        "Overridden because [domain/path] section for multiple-adapter domain."
         return cls.getSiteDomain()+cls.getPathToArchive()
 
     @classmethod

--- a/fanficfare/adapters/adapter_sinfuldreamscomwickedtemptation.py
+++ b/fanficfare/adapters/adapter_sinfuldreamscomwickedtemptation.py
@@ -31,7 +31,7 @@ class SinfulDreamsComWickedTemptation(BaseEfictionAdapter):
 
     @classmethod
     def getConfigSection(cls):
-        "Overriden because [domain/path] section for multiple-adapter domain."
+        "Overridden because [domain/path] section for multiple-adapter domain."
         return cls.getSiteDomain()+cls.getPathToArchive()
 
     @classmethod

--- a/fanficfare/adapters/adapter_siyecouk.py
+++ b/fanficfare/adapters/adapter_siyecouk.py
@@ -99,7 +99,7 @@ class SiyeCoUkAdapter(BaseSiteAdapter): # XXX
         # need(or easier) to pull other metadata from the author's list page.
         authsoup = self.make_soup(self.get_request(self.story.getMetadata('authorUrl')))
 
-        # remove author profile incase they've put the story URL in their bio.
+        # remove author profile in case they've put the story URL in their bio.
         profile = authsoup.find('div',{'id':'profile'})
         if profile: # in case it changes.
             profile.extract()

--- a/fanficfare/adapters/adapter_starslibrarynet.py
+++ b/fanficfare/adapters/adapter_starslibrarynet.py
@@ -33,7 +33,7 @@ class StarsLibraryNetAdapter(BaseEfictionAdapter):
     ## starslibrary.net is a replacement for pre-existing twcslibrary.net.
     @classmethod
     def getConfigSections(cls):
-        "Only needs to be overriden if has additional ini sections."
+        "Only needs to be overridden if has additional ini sections."
         return super(StarsLibraryNetAdapter, cls).getConfigSections()+['www.'+cls.getConfigSection(),'www.twcslibrary.net']
 
     @classmethod

--- a/fanficfare/adapters/adapter_storiesonlinenet.py
+++ b/fanficfare/adapters/adapter_storiesonlinenet.py
@@ -192,8 +192,8 @@ class StoriesOnlineNetAdapter(BaseSiteAdapter):
         self._setURL(url.replace("?ind=1",""))
         # logger.debug(data)
 
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+        if "Access denied. This story has not been validated by the administrators of this site." in data:
+            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the administrators of this site.")
         elif "Error! The story you're trying to access is being filtered by your choice of contents filtering." in data:
             raise exceptions.FailedToDownload(self.getSiteDomain() +" says: Error! The story you're trying to access is being filtered by your choice of contents filtering.")
         elif "Error! Daily Limit Reached" in data or "Sorry! You have reached your daily limit of" in data:
@@ -589,7 +589,7 @@ class StoriesOnlineNetAdapter(BaseSiteAdapter):
                 # Something's broken...
                 chapter_title = h2tag.extract()
 
-        # Strip te header section
+        # Strip the header section
         tag = pagetag.find('header')
         if tag:
             #logger.debug("remove before header: {0}".format(tag))

--- a/fanficfare/adapters/adapter_tenhawkpresents.py
+++ b/fanficfare/adapters/adapter_tenhawkpresents.py
@@ -115,8 +115,8 @@ class TenhawkPresentsSiteAdapter(BaseSiteAdapter):
         if "This story contains mature content which may include violence, sexual situations, and coarse language" in data:
             raise exceptions.AdultCheckRequired(self.url)
 
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+        if "Access denied. This story has not been validated by the administrators of this site." in data:
+            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the administrators of this site.")
 
         soup = self.make_soup(data)
 

--- a/fanficfare/adapters/adapter_themasquenet.py
+++ b/fanficfare/adapters/adapter_themasquenet.py
@@ -150,8 +150,8 @@ class TheMasqueNetAdapter(BaseSiteAdapter):
             else:
                 raise exceptions.AdultCheckRequired(self.url)
 
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+        if "Access denied. This story has not been validated by the administrators of this site." in data:
+            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the administrators of this site.")
 
         soup = self.make_soup(data)
         # print data
@@ -174,7 +174,7 @@ class TheMasqueNetAdapter(BaseSiteAdapter):
 
 
         # eFiction sites don't help us out a lot with their meta data
-        # formating, so it's a little ugly.
+        # formatting, so it's a little ugly.
 
         # utility method
         def defaultGetattr(d,k):
@@ -183,7 +183,7 @@ class TheMasqueNetAdapter(BaseSiteAdapter):
             except:
                 return ""
 
-# summary, rated, word count, categories, characters, genre, warnings, completed, published, updated, seires
+# summary, rated, word count, categories, characters, genre, warnings, completed, published, updated, series
 
         # <span class="label">Rated:</span> NC-17<br /> etc
         labels = soup.findAll('span',{'class':'label'})

--- a/fanficfare/adapters/adapter_trekfanfictionnet.py
+++ b/fanficfare/adapters/adapter_trekfanfictionnet.py
@@ -196,7 +196,7 @@ class TrekFanFictionNetSiteAdapter(BaseSiteAdapter):
         ## the content, but I have not idea which is more common.  No
         ## updates on the site in over a year, so I'm not going to
         ## worry about it too hard. --JM
-        ## this site has mulitple divs within the content section, so I'm going to remove them.
+        ## this site has multiple divs within the content section, so I'm going to remove them.
         for tag in story.find_all('div'):
             tag.extract()
 

--- a/fanficfare/adapters/adapter_twilightednet.py
+++ b/fanficfare/adapters/adapter_twilightednet.py
@@ -105,8 +105,8 @@ class TwilightedNetSiteAdapter(BaseSiteAdapter):
             self.performLogin(url)
             data = self.get_request(url)
 
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+        if "Access denied. This story has not been validated by the administrators of this site." in data:
+            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the administrators of this site.")
 
         # problems with some stories, but only in calibre.  I suspect
         # issues with different SGML parsers in python.  This is a

--- a/fanficfare/adapters/adapter_walkingtheplankorg.py
+++ b/fanficfare/adapters/adapter_walkingtheplankorg.py
@@ -93,8 +93,8 @@ class WalkingThePlankOrgAdapter(BaseSiteAdapter):
         if "By clicking this link, you acknowledge" in data:
             raise exceptions.AdultCheckRequired(self.url)
 
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+        if "Access denied. This story has not been validated by the administrators of this site." in data:
+            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the administrators of this site.")
 
         soup = self.make_soup(data)
         # print data
@@ -117,7 +117,7 @@ class WalkingThePlankOrgAdapter(BaseSiteAdapter):
 
 
         # eFiction sites don't help us out a lot with their meta data
-        # formating, so it's a little ugly.
+        # formatting, so it's a little ugly.
 
         # utility method
         def defaultGetattr(d,k):

--- a/fanficfare/adapters/adapter_wolverineandroguecom.py
+++ b/fanficfare/adapters/adapter_wolverineandroguecom.py
@@ -78,8 +78,8 @@ class WolverineAndRogueComAdapter(BaseSiteAdapter):
 
         data = self.get_request(url)
 
-        if "Access denied. This story has not been validated by the adminstrators of this site." in data:
-            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the adminstrators of this site.")
+        if "Access denied. This story has not been validated by the administrators of this site." in data:
+            raise exceptions.AccessDenied(self.getSiteDomain() +" says: Access denied. This story has not been validated by the administrators of this site.")
 
         soup = self.make_soup(data)
         # print data
@@ -106,7 +106,7 @@ class WolverineAndRogueComAdapter(BaseSiteAdapter):
 
 
         # eFiction sites don't help us out a lot with their meta data
-        # formating, so it's a little ugly.
+        # formatting, so it's a little ugly.
 
         # <span class="label">Rated:</span> NC-17<br /> etc
         content=soup.find('div',{'class' : 'content'})

--- a/fanficfare/adapters/adapter_wuxiaworldxyz.py
+++ b/fanficfare/adapters/adapter_wuxiaworldxyz.py
@@ -59,7 +59,7 @@ class WuxiaWorldXyzSiteAdapter(BaseSiteAdapter):
 
     @classmethod
     def getConfigSections(cls):
-        "Only needs to be overriden if has additional ini sections."
+        "Only needs to be overridden if has additional ini sections."
         return cls.getAcceptDomains()
 
     @classmethod

--- a/fanficfare/adapters/base_adapter.py
+++ b/fanficfare/adapters/base_adapter.py
@@ -102,7 +102,7 @@ class BaseSiteAdapter(Requestable):
         ## for doing some performance profiling.
         self.times = TimeKeeper()
 
-        ## Save class inheritence list in metadata.  Must be added to
+        ## Save class inheritance list in metadata.  Must be added to
         ## extra_valid_entries to use.
         cl = [ c.__name__ for c in inspect.getmro(self.__class__)[::-1] ]
         cl.remove('object') # remove a few common-to-all classes
@@ -320,7 +320,7 @@ class BaseSiteAdapter(Requestable):
         if not self.metadataDone:
             try:
                 ## virtually all adapters were catching 404s during
-                ## metdata fetch and raising StoryDoesNotExist.
+                ## metadata fetch and raising StoryDoesNotExist.
                 ## Consolidate in one place.
                 self.doExtractChapterUrlsAndMetadata(get_cover=get_cover)
             except HTTPErrorFFF as e:
@@ -373,27 +373,27 @@ class BaseSiteAdapter(Requestable):
 
     @staticmethod
     def getSiteDomain():
-        "Needs to be overriden in each adapter class."
+        "Needs to be overridden in each adapter class."
         return 'no such domain'
 
     @classmethod
     def getSiteURLFragment(self):
-        "Needs to be overriden in case of adapters that share a domain."
+        "Needs to be overridden in case of adapters that share a domain."
         return self.getSiteDomain()
 
     @classmethod
     def getConfigSection(cls):
-        "Only needs to be overriden if != site domain."
+        "Only needs to be overridden if != site domain."
         return cls.getSiteDomain()
 
     @classmethod
     def getConfigSections(cls):
-        "Only needs to be overriden if has additional ini sections."
+        "Only needs to be overridden if has additional ini sections."
         return [cls.getConfigSection()]
 
     @classmethod
     def stripURLParameters(cls,url):
-        "Only needs to be overriden if URL contains more than one parameter"
+        "Only needs to be overridden if URL contains more than one parameter"
         ## remove any trailing '&' parameters--?sid=999 will be left.
         ## that's all that any of the current adapters need or want.
         return re.sub(r"&.*$","",url)
@@ -410,7 +410,7 @@ class BaseSiteAdapter(Requestable):
     def getSiteExampleURLs(cls):
         """
         Return a string of space separated example URLs.
-        Needs to be overriden in each adapter class.  It's the adapter
+        Needs to be overridden in each adapter class.  It's the adapter
         writer's responsibility to make sure the example(s) pass the
         validateURL method.
         """
@@ -429,14 +429,14 @@ class BaseSiteAdapter(Requestable):
         return self.extractChapterUrlsAndMetadata()
 
     def extractChapterUrlsAndMetadata(self):
-        "Needs to be overriden in each adapter class.  Populates self.story metadata"
+        "Needs to be overridden in each adapter class.  Populates self.story metadata"
 
     def getChapterTextNum(self, url, index):
         "For adapters that also want to know the chapter index number."
         return self.getChapterText(url)
 
     def getChapterText(self, url):
-        "Needs to be overriden in each adapter class."
+        "Needs to be overridden in each adapter class."
 
     def before_get_urls_from_page(self,url,normalize):
         ## some sites need a login or other prep for 'from page' to

--- a/fanficfare/adapters/base_efiction_adapter.py
+++ b/fanficfare/adapters/base_efiction_adapter.py
@@ -73,7 +73,7 @@ class BaseEfictionAdapter(BaseSiteAdapter):
 
     @classmethod
     def getConfigSections(cls):
-        "Only needs to be overriden if has additional ini sections."
+        "Only needs to be overridden if has additional ini sections."
         return ['base_efiction',cls.getConfigSection()]
 
     @classmethod

--- a/fanficfare/adapters/base_otw_adapter.py
+++ b/fanficfare/adapters/base_otw_adapter.py
@@ -65,7 +65,7 @@ class BaseOTWAdapter(BaseSiteAdapter):
 
     @classmethod
     def getConfigSections(cls):
-        "Only needs to be overriden if has additional ini sections."
+        "Only needs to be overridden if has additional ini sections."
         return ['base_otw',cls.getConfigSection()]
 
     @classmethod

--- a/fanficfare/adapters/base_xenforo2forum_adapter.py
+++ b/fanficfare/adapters/base_xenforo2forum_adapter.py
@@ -38,7 +38,7 @@ class BaseXenForo2ForumAdapter(BaseXenForoForumAdapter):
 
     @classmethod
     def getConfigSections(cls):
-        "Only needs to be overriden if has additional ini sections."
+        "Only needs to be overridden if has additional ini sections."
         return super(BaseXenForo2ForumAdapter, cls).getConfigSections() + ['base_xenforo2forum']
 
     def performLogin(self,data):

--- a/fanficfare/adapters/base_xenforoforum_adapter.py
+++ b/fanficfare/adapters/base_xenforoforum_adapter.py
@@ -67,7 +67,7 @@ class BaseXenForoForumAdapter(BaseSiteAdapter):
 
     @classmethod
     def getConfigSections(cls):
-        "Only needs to be overriden if has additional ini sections."
+        "Only needs to be overridden if has additional ini sections."
         return ['base_xenforoforum',cls.getConfigSection()]
 
     @classmethod
@@ -345,7 +345,7 @@ class BaseXenForoForumAdapter(BaseSiteAdapter):
             date_sort_threadmarks = sorted(date_sort_threadmarks, key=lambda x: x['date'])
 
         threadmarks = date_sort_threadmarks + grouped_threadmarks
-        ## older setting, threadmarks_categories_ordered_by_date supercedes.
+        ## older setting, threadmarks_categories_ordered_by_date supersedes.
         if self.getConfig('order_threadmarks_by_date') and not self.getConfig('order_threadmarks_by_date_categories'):
             threadmarks = sorted(threadmarks, key=lambda x: x['date'])
         return threadmarks
@@ -539,7 +539,7 @@ class BaseXenForoForumAdapter(BaseSiteAdapter):
                         self.threadmarks_for_reader[self.normalize_chapterurl(tm['url'])] = (tm['tmcat_num'],tm['tmcat_index'])
 
                     ## threadmark date, words available for chapter custom output
-                    ## date formate from datethreadmark_format or dateCreated_format
+                    ## date format from datethreadmark_format or dateCreated_format
                     ## then a basic default.
                     added = self.add_chapter(prepend+tm['title'],tm['url'],{'date':tm['date'].strftime(self.getConfig("datethreadmark_format",self.getConfig("dateCreated_format","%Y-%m-%d %H:%M:%S"))),
                                                                             'words':tm['words'],

--- a/fanficfare/browsercache/browsercache_blockfile.py
+++ b/fanficfare/browsercache/browsercache_blockfile.py
@@ -108,9 +108,9 @@ class BlockfileCache(BaseChromiumCache):
 
     def get_data_key_impl(self, url, key):
         entry = None
-        entrys = parse(self.cache_dir,[key.encode('utf8')])
-        logger.debug(entrys)
-        for entry in entrys:
+        entries = parse(self.cache_dir,[key.encode('utf8')])
+        logger.debug(entries)
+        for entry in entries:
             entry_name = entry.keyToStr()
             logger.debug("Name: %s"%entry_name)
             logger.debug("Hash: 0x%08x"%entry.hash)

--- a/fanficfare/cli.py
+++ b/fanficfare/cli.py
@@ -65,7 +65,7 @@ def write_story(config, adapter, writeformat,
     return output_filename
 
 def mkParser(calibre, parser=None):
-    # read in args, anything starting with -- will be treated as --<varible>=<value>
+    # read in args, anything starting with -- will be treated as --<variable>=<value>
     if not parser:
         parser = OptionParser('usage: %prog [options] [STORYURL]...')
     parser.add_option('-f', '--format', dest='format', default='epub',
@@ -582,7 +582,7 @@ def get_configuration(url,
         # for case of list download.  Just makes more sense to me.
         configuration.read_file(StringIO(unicode(passed_defaultsini)))
     else:
-        # don't need to check existance for our selves.
+        # don't need to check existence for our selves.
         conflist.append(join(dirname(__file__), 'defaults.ini'))
         conflist.append(join(homepath, 'defaults.ini'))
         conflist.append(join(homepath2, 'defaults.ini'))

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -968,7 +968,7 @@ use_threadmark_wordcounts:true
 #tocpage_entry:
 # <a href="file${index04}.xhtml">${chapter}</a> ${date} ${kwords}<br /><br />
 
-## The 'date' value for chapters mentioned above can be formated with
+## The 'date' value for chapters mentioned above can be formatted with
 ## datethreadmark_format.  Otherwise it will default to
 ## dateCreated_format
 #datethreadmark_format:%%Y-%%m-%%d %%H:%%M
@@ -1657,7 +1657,7 @@ slow_down_sleep_time:2
 #tocpage_entry:
 # <a href="file${index04}.xhtml">${chapter}</a> ${date}<br /><br />
 
-## The 'date' value for chapters mentioned above can be formated with
+## The 'date' value for chapters mentioned above can be formatted with
 ## datechapter_format.  Otherwise it will default to
 ## datePublished_format
 #datechapter_format:%%Y-%%m-%%d
@@ -1906,7 +1906,7 @@ add_to_output_css:
 
 ## fiction.live spoilers display as a (blank) block until clicked, then they can become inline text.
 ## with true, adds them to an outlined block marked as a spoiler.
-## with false, the text of the spoiler is unmarked and present in the work, as though alreday clicked
+## with false, the text of the spoiler is unmarked and present in the work, as though already clicked
 #legend_spoilers:true
 ## display 'spoiler' tags in the tag list, which can contain plot details
 #show_spoiler_tags:false
@@ -2602,7 +2602,7 @@ slow_down_sleep_time:2
 #tocpage_entry:
 # <a href="file${index04}.xhtml">${chapter}</a> ${date}<br /><br />
 
-## The 'date' value for chapters mentioned above can be formated with
+## The 'date' value for chapters mentioned above can be formatted with
 ## datechapter_format.  Otherwise it will default to
 ## datePublished_format
 #datechapter_format:%%Y-%%m-%%d
@@ -2805,7 +2805,7 @@ extracategories:Star Trek
 ## adult content.  Uncomment by removing '#' in front of is_adult.
 #is_adult:true
 
-## This site has links to a vidow site embeded in the text. They are
+## This site has links to a vidow site embedded in the text. They are
 ## not needed, and will be removed if the below property is set to true
 strip_text_links:true
 
@@ -3038,7 +3038,7 @@ extra_valid_entries:house,era,spoilers,hits
 #tocpage_entry:
 # <a href="file${index04}.xhtml">${chapter}</a> ${date} ${words}<br /><br />
 
-## The 'date' value for chapters mentioned above can be formated with
+## The 'date' value for chapters mentioned above can be formatted with
 ## datechapter_format.  Otherwise it will default to
 ## datePublished_format
 #datechapter_format:%%Y-%%m-%%d
@@ -3226,7 +3226,7 @@ vote_rating_label:Votes(Rating)
 # <a href="file${index04}.xhtml">${chapter}</a> ${date} ${size}<br /><br />
 
 ## The 'date' and 'update' value for chapters mentioned above can be
-## formated with datechapter_format.  Otherwise it will default to
+## formatted with datechapter_format.  Otherwise it will default to
 ## datePublished_format
 #datechapter_format:%%Y-%%m-%%d
 

--- a/fanficfare/fetchers/log.py
+++ b/fanficfare/fetchers/log.py
@@ -25,7 +25,7 @@ def safe_url(url):
     return re.sub(safe_url_re,r'\g<attr>XXXXXXXX\g<amp>',url)
 
 ## Yes, I care about this debug out more than I really should.  But I
-## do watch it alot.
+## do watch it a lot.
 def make_log(where,method,url,hit=True,bar='=',barlen=10):
     return "\n%(bar)s %(hit)s (%(method)s) %(where)s\n%(url)s"%{
         'bar':bar*barlen,

--- a/fanficfare/geturls.py
+++ b/fanficfare/geturls.py
@@ -209,7 +209,7 @@ def get_urls_from_imap(srv,user,passwd,folder,markread=True):
     if status[0] != 'OK':
         raise FetchEmailFailed("Failed to list folders on mail server")
 
-    # Needs to be quoted incase there are spaces, etc.  imaplib
+    # Needs to be quoted in case there are spaces, etc.  imaplib
     # doesn't correctly quote folders with spaces.  However, it does
     # check and won't quote strings that already start and end with ",
     # so this is safe.  There may be other chars than " that need escaping.

--- a/fanficfare/htmlheuristics.py
+++ b/fanficfare/htmlheuristics.py
@@ -76,7 +76,7 @@ def replace_br_with_p(body):
 
     # if aggressive mode = true
         # blocksRegex = re.compile(r'(\s*<br\ */*>\s*)*\s*<(pre)([^>]*)>(.+?)</\2>\s*(\s*<br\ */*>\s*)*', re.DOTALL)
-        # In aggressive mode, we also check breakes inside blockquotes, meaning we can get orphaned paragraph tags.
+        # In aggressive mode, we also check breaks inside blockquotes, meaning we can get orphaned paragraph tags.
         # body = re.sub(r'<blockquote([^>]*)>(.+?)</blockquote>', r'<blockquote\1><p>\2</p></blockquote>', body, re.DOTALL)
     # end aggressive mode
 
@@ -202,7 +202,7 @@ def replace_br_with_p(body):
         body = breaksRegexp[0].sub(r'\1 \n\3', body)
 
     # Find all instances of consecutive breaks less than otr equal to the max count use most often
-    #  replase those tags to inverted p tag pairs, those with more connsecutive breaks are replaced them with a horisontal line
+    #  replace those tags to inverted p tag pairs, those with more connsecutive breaks are replaced them with a horisontal line
     for i in range(len(breaksCount)):
         # if i > 0 or breaksMaxIndex == 0:
         if i <= breaksMaxIndex:
@@ -245,9 +245,9 @@ def replace_br_with_p(body):
     # Repeated closing p tags are condenced to one
     body = re.sub(r'\s*(<\/\s*p>\s*){2,}', r'</p>\n', body)
 
-    # superflous cleaning, remove whitespaces traling opening p tags. These does affect formatting.
+    # superfluous cleaning, remove whitespaces trailing opening p tags. These does affect formatting.
     body = re.sub(r'\s*<p([^>]*)>\s*', r'\n<p\1>', body)
-    # superflous cleaning, remove whitespaces leading closing p tags. These does not affect formatting.
+    # superfluous cleaning, remove whitespaces leading closing p tags. These does not affect formatting.
     body = re.sub(r'\s*</p>\s*', r'</p>\n', body)
 
     # Remove empty tag pairs
@@ -260,7 +260,7 @@ def replace_br_with_p(body):
     # re-wrap in div tag.
     body = u'<div id="' +was_run_marker+ u'">\n' + body + u'</div>\n'
     # return body after tag_sanitizer with 'replace_br_with_p done' marker.
-    ## marker included twice becaues the comment & id could each be
+    ## marker included twice because the comment & id could each be
     ## removed by different 'clean ups'.  I hope it's less likely both
     ## will be.
     return u'<!-- ' +was_run_marker+ u' -->\n' + tag_sanitizer(body)

--- a/fanficfare/story.py
+++ b/fanficfare/story.py
@@ -146,7 +146,7 @@ except:
 
             if normalize_format_name(img.format) != imgtype:
                 if img.mode == "P":
-                    # convert pallete gifs to RGB so jpg save doesn't fail.
+                    # convert palette gifs to RGB so jpg save doesn't fail.
                     img = img.convert("RGB")
                 export = True
 
@@ -810,7 +810,7 @@ class Story(Requestable):
         # delete cached replace'd value.
         self.metadata_cache.invalidate(key)
 
-        # Fixing everything downstream to handle bool primatives is a
+        # Fixing everything downstream to handle bool primitives is a
         # pain.
         if isinstance(value,bool):
             value = unicode(value)
@@ -1632,7 +1632,7 @@ class Story(Requestable):
                         raise exceptions.FailedToDownload("ffdl image is internal only...")
                     bgcolor = self.getConfig('background_color','ffffff')
                     if not bgcolor or len(bgcolor)<3 or len(bgcolor)>6 or not re.match(r"^[0-9a-fA-F]+$",bgcolor):
-                        logger.info("background_color(%s) needs to be a hexidecimal color--using ffffff instead."%bgcolor)
+                        logger.info("background_color(%s) needs to be a hexadecimal color--using ffffff instead."%bgcolor)
                         bgcolor = 'ffffff'
                     try:
                         jpg_quality = int(self.getConfig('jpg_quality', '95'))

--- a/fanficfare/writers/base_writer.py
+++ b/fanficfare/writers/base_writer.py
@@ -257,4 +257,4 @@ class BaseStoryWriter(Requestable):
             outstream.close()
 
     def writeStoryImpl(self, out):
-        "Must be overriden by sub classes."
+        "Must be overridden by sub classes."

--- a/fanficfare/writers/writer_epub.py
+++ b/fanficfare/writers/writer_epub.py
@@ -312,7 +312,7 @@ div { margin: 0pt; padding: 0pt; }
         else:
             self.use_oldcover = False
 
-        ## Python 2.5 ZipFile is rather more primative than later
+        ## Python 2.5 ZipFile is rather more primitive than later
         ## versions.  It can operate on a file, or on a BytesIO, but
         ## not on an open stream.  OTOH, I suspect we would have had
         ## problems with closing and opening again to change the


### PR DESCRIPTION
Found via `codespell -S ./calibre-plugin/translations,./included_dependencies,./tests/fixtures_chireads.py -L dne,pres,signes,curren,als,ist,buss,serie,nd,waring,couldn,vie`