### PR TITLE
exclude_notes clarification in defaults.ini

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -1632,6 +1632,7 @@ add_to_replace_metadata:
 ## traditionally included them all in the chapter text, but this allows
 ## you to customize which you include.  Copy this parameter to your
 ## personal.ini and list the ones you don't want.
+## To retroactively apply settings to already-downloaded chapters, use 'Overwrite Always.'
 #exclude_notes:authorheadnotes,chaptersummary,chapterheadnotes,chapterfootnotes,authorfootnotes,inspiredlinks
 
 ## AO3 authorfootnotes and inspiredlinks end up in the 'last' chapter,
@@ -2577,6 +2578,7 @@ add_to_replace_metadata:
 ## traditionally included them all in the chapter text, but this allows
 ## you to customize which you include.  Copy this parameter to your
 ## personal.ini and list the ones you don't want.
+## To retroactively apply settings to already-downloaded chapters, use 'Overwrite Always.'
 #exclude_notes:authorheadnotes,chaptersummary,chapterheadnotes,chapterfootnotes,authorfootnotes,inspiredlinks
 
 ## OTW authorfootnotes and inspiredlinks end up in the 'last' chapter,
@@ -3488,6 +3490,7 @@ add_to_titlepage_entries:,views, averageWords, fandoms
 ## and inline footnotes.  We've traditionally included them all in the chapter
 ## text, but this allows you to customize which you include.  Copy this
 ## parameter to your personal.ini and list the ones you don't want.
+## To retroactively apply settings to already-downloaded chapters, use 'Overwrite Always.'
 #exclude_notes:authornotes,newsboxes,spoilers,footnotes
 
 [www.siye.co.uk]

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -1620,6 +1620,7 @@ add_to_replace_metadata:
 ## traditionally included them all in the chapter text, but this allows
 ## you to customize which you include.  Copy this parameter to your
 ## personal.ini and list the ones you don't want.
+## To retroactively apply settings to already-downloaded chapters, use 'Overwrite Always.'
 #exclude_notes:authorheadnotes,chaptersummary,chapterheadnotes,chapterfootnotes,authorfootnotes,inspiredlinks
 
 ## AO3 authorfootnotes and inspiredlinks end up in the 'last' chapter,
@@ -2565,6 +2566,7 @@ add_to_replace_metadata:
 ## traditionally included them all in the chapter text, but this allows
 ## you to customize which you include.  Copy this parameter to your
 ## personal.ini and list the ones you don't want.
+## To retroactively apply settings to already-downloaded chapters, use 'Overwrite Always.'
 #exclude_notes:authorheadnotes,chaptersummary,chapterheadnotes,chapterfootnotes,authorfootnotes,inspiredlinks
 
 ## OTW authorfootnotes and inspiredlinks end up in the 'last' chapter,
@@ -3458,6 +3460,7 @@ add_to_titlepage_entries:,views, averageWords, fandoms
 ## and inline footnotes.  We've traditionally included them all in the chapter
 ## text, but this allows you to customize which you include.  Copy this
 ## parameter to your personal.ini and list the ones you don't want.
+## To retroactively apply settings to already-downloaded chapters, use 'Overwrite Always.'
 #exclude_notes:authornotes,newsboxes,spoilers,footnotes
 
 [www.siye.co.uk]


### PR DESCRIPTION
This adds a note about retroactively applying exclude_notes changes to downloaded chapters.