### PR TITLE
Fix selector for xenforo2 stats, needed to pull word count estimate

### DIFF
--- a/fanficfare/adapters/base_xenforo2forum_adapter.py
+++ b/fanficfare/adapters/base_xenforo2forum_adapter.py
@@ -136,7 +136,7 @@ class BaseXenForo2ForumAdapter(BaseXenForoForumAdapter):
                         if img.has_attr('srcset'):
                             src = img['srcset']
                         self.setCoverImage(useurl,src)
-        stats = topsoup.find('span',class_='block-formSectionHeader-aligner')
+        stats = topsoup.find('span',class_='collapseTrigger collapseTrigger--block')
         if stats:
             m = re.search(r' (?P<words>[^ ]+) words\)',stripHTML(stats))
             if m:


### PR DESCRIPTION
I'm not sure when the `estimatedWords` scraping broke, I went to use it for a personal project using FanFicFare CLI to pull fic metadata and was surprised to find both `numWords` and `estimatedWords` as empty strings for fics pulled from SB, etc;