### PR TITLE
Skip invalid images

### DIFF
--- a/fanficfare/story.py
+++ b/fanficfare/story.py
@@ -201,10 +201,13 @@ def no_convert_image(url,data):
                 logger.info("no_convert_image url:%s - from bits got '%s'" % (url, ext))
             except (IOError, TypeError):
                 raise exceptions.RejectImage("no_convert_image url:%s - not a valid image"%url)
-            if ext not in imagetypes:
-                logger.info("no_convert_image url:%s - no known extension -- using .jpg"%url)
-                # doesn't have extension? use jpg.
-                ext='jpg'
+            except ImportError:
+                pass
+            finally:
+                if ext not in imagetypes:
+                    logger.info("no_convert_image url:%s - no known extension -- using .jpg"%url)
+                    # doesn't have extension? use jpg.
+                    ext='jpg'
 
     return (data,ext,imagetypes[ext])
 

--- a/fanficfare/story.py
+++ b/fanficfare/story.py
@@ -194,9 +194,17 @@ def no_convert_image(url,data):
         # parameter.
         ext = url[url.rfind('.')+1:].lower()
         if ext not in imagetypes:
-            logger.info("no_convert_image url:%s - no known extension -- using .jpg"%url)
-            # doesn't have extension? use jpg.
-            ext='jpg'
+            try:
+                from PIL import Image
+                from .six import BytesIO
+                ext = Image.open(BytesIO(data)).format.lower()
+                logger.info("no_convert_image url:%s - from bits got '%s'" % (url, ext))
+            except (IOError, TypeError):
+                raise exceptions.RejectImage("no_convert_image url:%s - not a valid image"%url)
+            if ext not in imagetypes:
+                logger.info("no_convert_image url:%s - no known extension -- using .jpg"%url)
+                # doesn't have extension? use jpg.
+                ext='jpg'
 
     return (data,ext,imagetypes[ext])
 


### PR DESCRIPTION
Downloading images with the 'no_convert_image' if the image was for example deleted the plugin pulls garbage and makes 0B image. This may solve the problem when downloading the images with no extension will result in a proper extension being applied instead of just jpg.