### PR TITLE
adapter_inkbunny: Fix author & category

### DIFF
--- a/fanficfare/adapters/adapter_inkbunnynet.py
+++ b/fanficfare/adapters/adapter_inkbunnynet.py
@@ -134,7 +134,7 @@ class InkBunnyNetSiteAdapter(BaseSiteAdapter):
         self.story.setMetadata('title', stripHTML(title))
 
         # Get Author
-        authortag = soup.find('table',{'class':'pooltable'}).find('a',href=re.compile(r'/gallery/'))
+        authortag = soup.find('table',{'class':'pooltable'}).find('a',href=re.compile(r'/gallery/|/scraps/'))
         author = authortag['href'].split('/')[-1] # no separate ID
         self.story.setMetadata('author', author)
         self.story.setMetadata('authorId', author)
@@ -157,10 +157,11 @@ class InkBunnyNetSiteAdapter(BaseSiteAdapter):
             self.story.addToList('genre', stripHTML(kword))
 
         # Getting the Category
+        category = bookdetails.findChildren('div', recursive=False)[2].find('span', string='Type:').parent
+        category.find('span').decompose()
+        self.story.setMetadata('category', stripHTML(category).strip())
         for div in bookdetails.find_all('div'):
-            if 'Details' == stripHTML(div).strip():
-                self.story.setMetadata('category', div.find_next_siblings('div')[0].span.next_sibling.strip())
-            elif 'Rating:' == stripHTML(div).strip()[:7]:
+            if 'Rating:' == stripHTML(div).strip()[:7]:
                 rating = div.span.next_sibling.strip()
                 self.story.setMetadata('rating', rating)
                 break

--- a/fanficfare/adapters/adapter_inkbunnynet.py
+++ b/fanficfare/adapters/adapter_inkbunnynet.py
@@ -159,9 +159,9 @@ class InkBunnyNetSiteAdapter(BaseSiteAdapter):
         # Getting the Category
         category = bookdetails.findChildren('div', recursive=False)[2].find('span', string='Type:').parent
         category.find('span').decompose()
-        self.story.setMetadata('category', stripHTML(category).strip())
+        self.story.setMetadata('category', stripHTML(category))
         for div in bookdetails.find_all('div'):
-            if 'Rating:' == stripHTML(div).strip()[:7]:
+            if 'Rating:' == stripHTML(div)[:7]:
                 rating = div.span.next_sibling.strip()
                 self.story.setMetadata('rating', rating)
                 break


### PR DESCRIPTION
If the work is in scraps the adapter fails to pull author failing the download. And the category wasn't being set for some reason on some of the works. This attempts to fix that.