### PR TITLE
adapter_spiritfanfictioncom: Fix missing raw str + cleanups

### DIFF
--- a/fanficfare/adapters/adapter_spiritfanfictioncom.py
+++ b/fanficfare/adapters/adapter_spiritfanfictioncom.py
@@ -14,7 +14,7 @@ from .base_adapter import BaseSiteAdapter,  makeDate
 
 def getClass():
     return SpiritFanfictionComAdapter
-    
+
 class SpiritFanfictionComAdapter(BaseSiteAdapter):
 
     def __init__(self, config, url):
@@ -28,15 +28,15 @@ class SpiritFanfictionComAdapter(BaseSiteAdapter):
         self._setURL('https://' + self.getSiteDomain() + '/historia/'+self.story.getMetadata('storyId'))
 
         # Each adapter needs to have a unique site abbreviation.
-        self.story.setMetadata('siteabbrev',self.getSiteAbbrev())
+        self.story.setMetadata('siteabbrev', self.getSiteAbbrev())
 
         # The date format will vary from site to site.
         # http://docs.python.org/library/datetime.html#strftime-strptime-behavior
-        self.dateformat = "%Y-%m-%dT%H:%M:%S%z"
+        self.dateformat = '%Y-%m-%dT%H:%M:%S%z'
 
         self.chapter_photoUrl = {}
 
-        
+
     @staticmethod
     def getSiteDomain():
         return 'www.spiritfanfiction.com'
@@ -51,22 +51,22 @@ class SpiritFanfictionComAdapter(BaseSiteAdapter):
 
     @classmethod
     def getSiteExampleURLs(cls):
-        #Accepted formats
-        #https://www.spiritfanfiction.com/historia/1234
-        #https://www.spiritfanfiction.com/historia/story-name-1234
-        return "https://"+cls.getSiteDomain()+"/historia/story-name-1234 https://"+cls.getSiteDomain()+"/historia/1234" 
+        # Accepted formats
+        # https://www.spiritfanfiction.com/historia/1234
+        # https://www.spiritfanfiction.com/historia/story-name-1234
+        return 'https://'+cls.getSiteDomain()+'/historia/story-name-1234 https://'+cls.getSiteDomain()+'/historia/1234'
 
 
     @classmethod
-    def getSiteURLPattern(self):
-        #logger.debug(r"https?://(" + r"|".join([x.replace('.','\.') for x in self.getAcceptDomains()]) + r")/historia/(?:[a-zA-Z0-9-]+-)?(?P<storyId>\d+)")
-        return r"https?://(" + r"|".join([x.replace('.','\.') for x in self.getAcceptDomains()]) + r")/historia/(?:[a-zA-Z0-9-]+-)?(?P<storyId>\d+)"
+    def getSiteURLPattern(cls):
+        # logger.debug(r'https?://(' + r'|'.join([x.replace(r'.',r'\.') for x in cls.getAcceptDomains()]) + r')/historia/(?:[a-zA-Z0-9-]+-)?(?P<storyId>\d+)')
+        return r'https?://(' + r'|'.join([x.replace(r'.', r'\.') for x in cls.getAcceptDomains()]) + r')/historia/(?:[a-zA-Z0-9-]+-)?(?P<storyId>\d+)'
 
 
     @classmethod
     def getSiteAbbrev(cls):
         return 'spirit'
-    
+
 
     def getStoryId(self, url):
 
@@ -86,12 +86,12 @@ class SpiritFanfictionComAdapter(BaseSiteAdapter):
         # Now go hunting for all the meta data and the chapter list.
 
         # Title
-        title = soup.find('h1', {'class':'tituloPrincipal'})
+        title = soup.find('h1', {'class': 'tituloPrincipal'})
         self.story.setMetadata('title', stripHTML(title.find('strong')))
-                                
+
         # Authors
         # Find authorid and URL
-        authors = soup.findAll('span', {'class':'usuario'})
+        authors = soup.findAll('span', {'class': 'usuario'})
 
         for author in authors:
             self.story.addToList('authorId', author.find('a')['href'].split('/')[-1])
@@ -99,35 +99,35 @@ class SpiritFanfictionComAdapter(BaseSiteAdapter):
             self.story.addToList('author', stripHTML(author.find('strong')))
 
         # Cover image
-        cover_img = soup.find('img', {'class':'imagemResponsiva'})
+        cover_img = soup.find('img', {'class': 'imagemResponsiva'})
         if cover_img:
             self.setCoverImage(self.url, cover_img['src'])
 
         newestChapter = None
-        self.newestChapterNum = None # save for comparing during update.
+        self.newestChapterNum = None  # save for comparing during update.
         # Find the chapters:
-        chapters = soup.findAll('table', {'class':'listagemCapitulos espacamentoTop'})
+        chapters = soup.findAll('table', {'class': 'listagemCapitulos espacamentoTop'})
         for chapter in chapters:
 
             for row in chapter.findAll('tr', {'class': 'listagem-textoBg1'}):  # Find each row with chapter info
                 a = row.find('a')  # Chapter link
 
                 # Datetime
-                date = a.find_next('time')['datetime']  
+                date = a.find_next('time')['datetime']
                 chapterDate = makeDate(date, self.dateformat).date()
 
                 chapter_title = stripHTML(a.find('strong'))
 
                 self.add_chapter(chapter_title, a.get('href'), {'date': chapterDate})
 
-                if newestChapter == None or chapterDate > newestChapter:
+                if newestChapter is None or chapterDate > newestChapter:
                     newestChapter = chapterDate
                     self.newestChapterNum = self.story.getMetadata('numChapters')
-            
+
         logger.debug('numChapters: (%s)', self.story.getMetadata('numChapters'))
 
         # Summary
-        div_element = soup.find('div', {'class':'clearfix'})
+        div_element = soup.find('div', {'class': 'clearfix'})
         summary = div_element.find('div', class_='texto')
 
         strong_tag = summary.find('strong', text='Sinopse:')
@@ -141,7 +141,7 @@ class SpiritFanfictionComAdapter(BaseSiteAdapter):
 
         full_text = unicode(summary)
         self.story.setMetadata('description', full_text)
-        
+
 
         def parse_until_br(attribute, start_index, element_list):
             # Initialize counter
@@ -157,11 +157,11 @@ class SpiritFanfictionComAdapter(BaseSiteAdapter):
                         elif element.contents[0].text == 'Não':
                             self.story.setMetadata(attribute, 'In-Progress')
                     elif attribute == 'characters':
-                        terms = re.findall(r"[^&]+", stripHTML(element))
+                        terms = re.findall(r'[^&]+', stripHTML(element))
                         for term in terms:
                             self.story.addToList(attribute, term)
                     elif attribute == 'numWords':
-                        self.story.setMetadata(attribute, stripHTML(element).replace('.',''))
+                        self.story.setMetadata(attribute, stripHTML(element).replace('.', ''))
                     else:
                         self.story.setMetadata(attribute, stripHTML(element))
                 elif element.name == 'a':
@@ -215,7 +215,7 @@ class SpiritFanfictionComAdapter(BaseSiteAdapter):
         # Extracting last word from class name
         if classificacao_element and 'class' in classificacao_element.attrs:
             class_value = classificacao_element.attrs['class']
-            self.story.setMetadata('rating',class_value[-1].split('-')[-1])
+            self.story.setMetadata('rating', class_value[-1].split('-')[-1])
 
         # Extracting text content "Gêneros" and "Avisos"
         contents = classificacao_element.find_next('div').contents
@@ -229,47 +229,47 @@ class SpiritFanfictionComAdapter(BaseSiteAdapter):
             else:
                 i += 1
 
-    ## Normalize chapter URLs in case of title change
-    def normalize_chapterurl(self,url):
-        #https://www.spiritfanfiction.com/historia/story-name-1234/capitulo56
-        url = re.sub(r"https?://("+self.getSiteDomain()+r"/historia/\d+/capitulo\d+)$",
-                     r"https://\1",url)
+    # Normalize chapter URLs in case of title change
+    def normalize_chapterurl(self, url):
+        # https://www.spiritfanfiction.com/historia/story-name-1234/capitulo56
+        url = re.sub(r'https?://('+self.getSiteDomain()+r'/historia/\d+/capitulo\d+)$',
+                     r'https://\1', url)
         return url
 
 
     def getChapterText(self, url):
         logger.debug('Getting chapter text from: %s' % url)
 
-        save_chapter_soup = self.make_soup("<div></div>")
+        save_chapter_soup = self.make_soup('<div></div>')
         save_chapter = save_chapter_soup.find('div')
 
         chapter_dl_soup = self.make_soup(self.get_request(url))
-        if None == chapter_dl_soup:
-            raise exceptions.FailedToDownload("Error downloading Chapter: %s!  Missing required element!" % url)
-        div_chapter = chapter_dl_soup.find('div', {'class':'clearfix'})
+        if chapter_dl_soup is None:
+            raise exceptions.FailedToDownload('Error downloading Chapter: %s!  Missing required element!' % url)
+        div_chapter = chapter_dl_soup.find('div', {'class': 'clearfix'})
         chapter_text = div_chapter.find('div', class_='texto-capitulo')
 
-        exclude_notes=self.getConfigList('exclude_notes')
+        exclude_notes = self.getConfigList('exclude_notes')
 
 
         def append_tag(elem, tag, string=None, classes=None):
-            '''bs4 requires tags be added separately.'''
+            """bs4 requires tags be added separately."""
             new_tag = save_chapter_soup.new_tag(tag)
             if string:
-                new_tag.string=string
+                new_tag.string = string
             if classes:
-                new_tag['class']=[classes]
+                new_tag['class'] = [classes]
             elem.append(new_tag)
             return new_tag
 
 
         chapimg = chaphead = chapfoot = None
         # Chapter Image
-        img_url = chapter_text.find('img', {'class':'imagemResponsiva'})
+        img_url = chapter_text.find('img', {'class': 'imagemResponsiva'})
         if img_url:
-            chapimg = chapter_dl_soup.new_tag('p', style="text-align: center")
+            chapimg = chapter_dl_soup.new_tag('p', style='text-align: center')
             chapimg.insert(0, chapter_dl_soup.new_tag('img', src=img_url['src']))
-        
+
         for tag in chapter_text.find_all('h2'):
             if tag.string.startswith('Notas do Autor'):
                 chaphead = self.make_soup(unicode(tag.find_next_sibling('div', {'class': 'texto texto-capitulo-notas'})))
@@ -280,43 +280,43 @@ class SpiritFanfictionComAdapter(BaseSiteAdapter):
                 chaptext = self.make_soup(unicode(tag.find_next_sibling('div', {'class': 'texto'})))
                 # Decode emails
                 self.decode_emails(chaptext)
-                if chapimg != None:
-                    if chaptext.div == None:
+                if chapimg is not None:
+                    if chaptext.div is None:
                         append_tag(chaptext, 'div')
                     chaptext.div.insert(0, chapimg)
 
-        head_notes_div = append_tag(save_chapter,'div',classes="fff_chapter_notes fff_head_notes")
+        head_notes_div = append_tag(save_chapter, 'div', classes='fff_chapter_notes fff_head_notes')
         if 'chapterheadnotes' not in exclude_notes:
-            if chaphead != None:
-                append_tag(head_notes_div,'b',"Notas do Autor:")
+            if chaphead is not None:
+                append_tag(head_notes_div, 'b', 'Notas do Autor:')
                 self.decode_emails(chaphead)
                 head_notes_div.append(chaphead)
-                append_tag(head_notes_div,'hr')
+                append_tag(head_notes_div, 'hr')
 
         save_chapter.append(chaptext)
 
-        foot_notes_div = append_tag(save_chapter,'div',classes="fff_chapter_notes fff_foot_notes")
-        ## Can appear on every chapter
+        foot_notes_div = append_tag(save_chapter, 'div', classes='fff_chapter_notes fff_foot_notes')
+        # Can appear on every chapter
         if 'chapterfootnotes' not in exclude_notes:
-            if chapfoot != None:
-                append_tag(foot_notes_div,'hr')
-                append_tag(foot_notes_div,'b',"Notas Finais:")
+            if chapfoot is not None:
+                append_tag(foot_notes_div, 'hr')
+                append_tag(foot_notes_div, 'b', 'Notas Finais:')
                 self.decode_emails(chapfoot)
                 foot_notes_div.append(chapfoot)
 
-        ## remove empty head/food notes div(s)
+        # remove empty head/food notes div(s)
         if not head_notes_div.find(True):
             head_notes_div.extract()
         if not foot_notes_div.find(True):
             foot_notes_div.extract()
 
-        return self.utf8FromSoup(url,save_chapter)
-    
+        return self.utf8FromSoup(url, save_chapter)
+
 
     def decode_emails(self, html_text):
 
         def decode_email(encoded_email):
-            email = ""
+            email = ''
             r = int(encoded_email[:2], 16)
             for i in range(2, len(encoded_email), 2):
                 char_code = int(encoded_email[i:i + 2], 16) ^ r
@@ -335,4 +335,3 @@ class SpiritFanfictionComAdapter(BaseSiteAdapter):
                 # Replace the obfuscated email with the decoded email
                 element.string = decoded_email
         return unicode(html_text)
-    


### PR DESCRIPTION
Core functional changes:
- Add one forgotten raw string literal usage (for `r'\.'`)
- Use identity comparisons for None (`is None`, `is not None`)

Also made style a bit more consistent:
- Quote usage (singles for string literals, doubles
  for docstrings)
- Spacing around #, operators, parameter lists

(Was guided by flake8, didn't touch clear stylistic differences such as
spacing between functions, spacing between function headers and bodies,
etc. May have missed some instances)
