### PR TITLE
Literotica Customizations (dates & tags)

### DIFF
--- a/fanficfare/adapters/adapter_literotica.py
+++ b/fanficfare/adapters/adapter_literotica.py
@@ -353,6 +353,7 @@ class LiteroticaSiteAdapter(BaseSiteAdapter):
         raw_page = self.get_request(url)
         page_soup = self.make_soup(raw_page)
         pages = page_soup.find('div',class_='l_bH')
+        self.story.extendList('eroticatags',[ stripHTML(t) for t in page_soup.select('div#tabpanel-tags a.av_as') ])
 
         fullhtml = ""
         chapter_description = ''

--- a/fanficfare/adapters/adapter_literotica.py
+++ b/fanficfare/adapters/adapter_literotica.py
@@ -220,18 +220,8 @@ class LiteroticaSiteAdapter(BaseSiteAdapter):
         else:
             ## Multi-chapter stories.  AKA multi-part 'Story Series'.
             bn_antags = soup.select('div#tabpanel-info p.bn_an')
-            # logger.debug(bn_antags)
-            # if bn_antags:
-            #     dates = []
-            #     for datetag in bn_antags[:2]:
-            #         datetxt = stripHTML(datetag)
-            #         # remove 'Started:' 'Updated:'
-            #         # Assume can't use 'Started:' 'Updated:' (vs [0] or [1]) because of lang localization
-            #         datetxt = datetxt[datetxt.index(':')+1:]
-            #         dates.append(datetxt)
-            #     # logger.debug(dates)
-            #     self.story.setMetadata('datePublished', makeDate(dates[0], self.dateformat))
-            #     self.story.setMetadata('dateUpdated', makeDate(dates[1], self.dateformat))
+
+            # Custom code to set pub and update dates to approved dates on oldest and newest chapters respectively
             date = re.findall(r'"date_approve":"(\d\d/\d\d/\d\d\d\d)"',data)
             # logger.debug(date)
             if date:
@@ -241,6 +231,7 @@ class LiteroticaSiteAdapter(BaseSiteAdapter):
                 datevallast = makeDate(sorted_date[-1], self.dateformat)
                 self.story.setMetadata('datePublished', datevalfirst)
                 self.story.setMetadata('dateUpdated', datevallast)
+                
             ## bn_antags[2] contains "The author has completed this series." or "The author is still actively writing this series."
             ## I won't be surprised if this breaks later because of lang localization
             if "completed" in stripHTML(bn_antags[-1]):


### PR DESCRIPTION
I've made a couple of minor changes based on literotica's site behavior and quirks and my own personal preference. As these are mostly personal preferences feel free to reject or modify as needed. I've listed my reasoning below, but I will take no offense if these aren't appropriate for inclusion. :)

1. I modified the tag gathering to pull tags from all individual chapters. It's more comprehensive and gives me more of the metadata I'm personally looking for. 
2. Changed how the dates are set for series. The date currently being pulled is the date that the series metadata itself was updated by literotica. This is misleading, as it updates even on automated changes (such as the recent UI overhaul), not on when the actual content was updated. Using the approved dates on individual chapters gives me more accurate metadata as to when the actual content was updated, which is what I'm most interested in. 