### PR TITLE
adapter_ficbooknet: Fixes for site changes

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -1939,8 +1939,6 @@ add_to_output_css:
     white-space: pre-wrap;
  }
 
-# 'collections' may generate a lot of requests if the work is included in many
-# collections. For every 30 there will be additional request made.
 extra_valid_entries:dedication,authorcomment,likes,follows,reviews,numCollections,pages,numAwards,classification
 
 dedication_label:Dedication
@@ -1950,7 +1948,6 @@ follows_label:Follows
 reviews_label:Reviews
 numCollections_label:Collections
 pages_label:Pages
-collections_label:Collections
 numAwards_label:Awards
 awards_label:Awards
 classification_label:FBN Category

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -1934,8 +1934,6 @@ add_to_output_css:
     white-space: pre-wrap;
  }
 
-# 'collections' may generate a lot of requests if the work is included in many
-# collections. For every 30 there will be additional request made.
 extra_valid_entries:dedication,authorcomment,likes,follows,reviews,numCollections,pages,numAwards,classification
 
 dedication_label:Dedication
@@ -1945,7 +1943,6 @@ follows_label:Follows
 reviews_label:Reviews
 numCollections_label:Collections
 pages_label:Pages
-collections_label:Collections
 numAwards_label:Awards
 awards_label:Awards
 classification_label:FBN Category


### PR DESCRIPTION
Additionally: 
Remove 'collections' entry to reduce unnecessary requests.
Added the `hr` to the chapter notes to mimic the site.
Haven't tested if works in py2