### PR TITLE
adapter_fimfictionnet: Fetch stories only found in bookshelf.

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -3809,6 +3809,9 @@ dateUpdated_format:%%Y-%%m-%%d %%H:%%M:%%S
 
 [www.fimfiction.net]
 use_basic_cache:true
+
+slow_down_sleep_time: 2
+
 ## Some sites require login (or login for some rated stories) The
 ## program can prompt you, or you can save it in config.  In
 ## commandline version, this should go in your personal.ini, not
@@ -3842,13 +3845,12 @@ fix_fimf_blockquotes:true
 ## chapter text.
 #include_author_notes:false
 
-
 ## This option aims to allow easy fetching of the stories on the
 ## bookshelf and exclude stories that are not in there.
 ## There are 3 options:
 ## false - fetch the only one page of stories provided by the user
 ## true - fetch all the stories from the point provided by the user
-## off - fetch the stories the old way.
+## legacy - fetch the stories the old way.
 #scrape_bookshelf: false
 
 ## some sites include images that we don't ever want becoming the

--- a/fanficfare/adapters/adapter_fimfictionnet.py
+++ b/fanficfare/adapters/adapter_fimfictionnet.py
@@ -407,7 +407,7 @@ class FimFictionNetSiteAdapter(BaseSiteAdapter):
 
     def get_urls_from_page(self,url,normalize):
         iterate = self.getConfig('scrape_bookshelf', default=False)
-        if not re.search(r'fimfiction\.net/bookshelf/(?P<listid>.+?)/',url) or iterate == 'off':
+        if not re.search(r'fimfiction\.net/bookshelf/(?P<listid>.+?)/',url) or iterate == 'legacy':
             return super().get_urls_from_page(url,normalize)
 
         self.before_get_urls_from_page(url,normalize)

--- a/fanficfare/configurable.py
+++ b/fanficfare/configurable.py
@@ -234,7 +234,7 @@ def get_valid_set_options():
 
                'fix_fimf_blockquotes':(['fimfiction.net'],None,boollist),
                'keep_prequel_in_description':(['fimfiction.net'],None,boollist),
-               'scrape_bookshelf':(['fimfiction.net'],None,boollist+['off']),
+               'scrape_bookshelf':(['fimfiction.net'],None,boollist+['legacy']),
                'include_author_notes':(['fimfiction.net','readonlymind.com','royalroad.com','syosetu.com'],None,boollist),
                'do_update_hook':(otw_list,None,boollist),
                'always_login':(['syosetu.com','fimfiction.net','inkbunny.net']+otw_list+base_xenforo_list,None,boollist),

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -3784,6 +3784,9 @@ dateUpdated_format:%%Y-%%m-%%d %%H:%%M:%%S
 
 [www.fimfiction.net]
 use_basic_cache:true
+
+slow_down_sleep_time: 2
+
 ## Some sites require login (or login for some rated stories) The
 ## program can prompt you, or you can save it in config.  In
 ## commandline version, this should go in your personal.ini, not
@@ -3822,7 +3825,7 @@ fix_fimf_blockquotes:true
 ## There are 3 options:
 ## false - fetch the only one page of stories provided by the user
 ## true - fetch all the stories from the point provided by the user
-## off - fetch the stories the old way.
+## legacy - fetch the stories the old way.
 #scrape_bookshelf: false
 
 ## some sites include images that we don't ever want becoming the


### PR DESCRIPTION
For issue #1018 
The only problem with this is that the loop will fetch pages as quickly as it can execute. Since the site uses cloudflare, this becomes an issue when fetching a large bookshelf. How can I apply a sleep time to the requests to mitigate this?