### PR TITLE
Update adapter_storiesonlinenet.py

### DIFF
--- a/fanficfare/adapters/adapter_storiesonlinenet.py
+++ b/fanficfare/adapters/adapter_storiesonlinenet.py
@@ -218,10 +218,8 @@ class StoriesOnlineNetAdapter(BaseSiteAdapter):
             ## both 's Page and ’s Page
             self.story.addToList('author',re.sub(r".s Page$","",stripHTML(a)))
 
-        # The rest of the metadata is within the article tag.
-        soup = soup.find('article')
-
         # Find the chapters:
+        # If multiple chapters, they are in "index-list" div.
         #    <a href="/s/00001/This-is-a-test/1">Chapter 1</a>
         #    <a href="/n/00001/This-is-a-test/1">Chapter 1</a>
         chapters = soup.select('div#index-list a[href*="/s/"],div#index-list a[href*="/n/"]')
@@ -234,6 +232,8 @@ class StoriesOnlineNetAdapter(BaseSiteAdapter):
         else:
             self.add_chapter(self.story.getMetadata('title'),self.story.getMetadata('storyUrl'))
 
+        # The rest of the metadata is within the article tag.
+        soup = soup.find('article')
 
         self.getStoryMetadataFromAuthorPage()
 


### PR DESCRIPTION
Moved soup.find for article below chapter search code, as chapter list code breaks when the description/details contains extraneous /div tag because the soup.find line overwrites "soup" ending at /div, so the index-list below description is truncated.