### PR TITLE
[BrowserCache] Add 'directimages'

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -1953,6 +1953,9 @@ use_basic_cache:true
 ## browser cache will only be used if use_browser_cache:true and ONLY
 ## for a few sites.  Requires a browser_cache_path set in
 ## [defaults].
+## This configurable also accept 'directimages' if you want to ignore
+## the BrowserCache for downloading images even if use_browser_cache_only is true. 
+## This is useful for sites that deliver images with a no-cache attribute.
 #use_browser_cache:false
 
 ## use_browser_cache_only:true prevents FFF from falling through to

--- a/fanficfare/configurable.py
+++ b/fanficfare/configurable.py
@@ -218,7 +218,7 @@ def get_valid_set_options():
                ## currently, browser_cache_path is assumed to be
                ## shared and only ffnet uses it so far
                'browser_cache_path':(['defaults'],None,None),
-               'use_browser_cache':(None,None,boollist),
+               'use_browser_cache':(None,None,boollist+['directimages']),
                'use_browser_cache_only':(None,None,boollist),
                'open_pages_in_browser':(None,None,boollist),
 

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -1948,6 +1948,9 @@ use_basic_cache:true
 ## browser cache will only be used if use_browser_cache:true and ONLY
 ## for a few sites.  Requires a browser_cache_path set in
 ## [defaults].
+## This configurable also accept 'directimages' if you want to ignore
+## the BrowserCache for downloading images even if use_browser_cache_only is true. 
+## This is useful for sites that deliver images with a no-cache attribute.
 #use_browser_cache:false
 
 ## use_browser_cache_only:true prevents FFF from falling through to

--- a/fanficfare/story.py
+++ b/fanficfare/story.py
@@ -744,10 +744,15 @@ class Story(Requestable):
         self.chapter_text_replacements_prepped = False
 
         self.chapter_error_count = 0
+
+        # direct_fetcher is used for downloading image in some case
+        # by using RequestsFetcher instead of the expected fetcher 
         self.direct_fetcher = None
         if self.getConfig('use_flaresolverr_proxy'):
             logger.debug("use_flaresolverr_proxy:%s"%self.getConfig('use_flaresolverr_proxy'))
-        if self.getConfig('use_flaresolverr_proxy') == 'directimages':
+        if self.getConfig('use_browser_cache'):
+            logger.debug("use_browser_cache:%s"%self.getConfig('use_browser_cache'))
+        if self.getConfig('use_flaresolverr_proxy') == 'directimages' or self.getConfig('use_browser_cache') == 'directimages':
             from . import fetchers
             fetcher = fetchers.RequestsFetcher(self.getConfig,
                                                self.getConfigList)

--- a/fanficfare/story.py
+++ b/fanficfare/story.py
@@ -1549,10 +1549,10 @@ class Story(Requestable):
     def addImgUrl(self,parenturl,url,fetch,cover=None,coverexclusion=None):
         logger.debug("addImgUrl(parenturl=%s,url=%s,cover=%s,coverexclusion=%s"%(parenturl,url,cover,coverexclusion))
 
-        ## flaresolverr can't download images, this directly downloads
-        ## them using RequestsFetcher.
+        ## flaresolverr can't download images and browser_cache can be setup to ignore image,
+        ## so this directly downloads them using RequestsFetcher.
         if self.direct_fetcher:
-            logger.debug("addImgUrl: use_flaresolverr_proxy:directimages")
+            # logger.debug("addImgUrl: using direct_fetcher")
             fetch = self.direct_fetcher
 
         # otherwise it saves the image in the epub even though it


### PR DESCRIPTION
This is a rework of #1175 with the configurable moved into `use_browser_cache` 

This is useful in the following context:
- A Site behind Cloudfare that reject the normal fetcher (AO3) so downloading need ` use_browser_cache` and ` use_browser_cache_only` 
- But the hosting site for story images set a no-cache header so the image is never in the BrowserCache

We already had a way to manage images with FlareSolverr, this patch hook into this existing infrastructure (`direct_fetcher`)