### PR TITLE
Reject HTML sites in no_convert_image

### DIFF
--- a/fanficfare/story.py
+++ b/fanficfare/story.py
@@ -31,6 +31,7 @@ from . import six
 from .six.moves.urllib.parse import (urlparse, urlunparse)
 from .six import text_type as unicode
 from .six import string_types as basestring
+from .six import ensure_binary
 
 import bs4
 
@@ -188,6 +189,13 @@ def no_convert_image(url,data):
     parsedUrl = urlparse(url)
 
     ext=parsedUrl.path[parsedUrl.path.rfind('.')+1:].lower()
+
+    try:
+        sample_data = ensure_binary(data[:50])
+        if b'<!doctype html>' in sample_data or b'<!DOCTYPE html>' in sample_data:
+            raise exceptions.RejectImage("no_convert_image url:%s - html site"%url)
+    except (UnicodeEncodeError, TypeError) as e:
+        logger.debug("no_convert_image url:%s - Exception: %s"%(url,str(e)))
 
     if ext not in imagetypes:
         # not found at end of path, try end of whole URL in case of


### PR DESCRIPTION
When using `no_image_processing`, if a website returns HTML rather than an image, the HTML is written to a file. For example, in `https://www.asianfanfics.com/story/view/315503/9/ulzzang-photo-gallery-open`, the  EPUB ends up being nearly 3MB, mostly filled with unreadable images that are actually HTML content. I couldn't test this change with py2 calibre as the proxy does not work on older versions.