### PR TITLE
New/replacement WPC/WLPC/SOL sub-site "storyroom.com" replacing "finestories.com"

### DIFF
--- a/fanficfare/adapters/__init__.py
+++ b/fanficfare/adapters/__init__.py
@@ -66,6 +66,7 @@ from . import adapter_themasquenet
 from . import adapter_pretendercentrecom
 from . import adapter_darksolaceorg
 from . import adapter_finestoriescom
+from . import adapter_storyroomcom
 from . import adapter_dracoandginnycom
 from . import adapter_wolverineandroguecom
 from . import adapter_thehookupzonenet

--- a/fanficfare/adapters/adapter_storyroomcom.py
+++ b/fanficfare/adapters/adapter_storyroomcom.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2013 Fanficdownloader team, 2018 FanFicFare team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import absolute_import
+import logging
+logger = logging.getLogger(__name__)
+
+# py2 vs py3 transition
+
+from .adapter_storiesonlinenet import StoriesOnlineNetAdapter
+
+def getClass():
+    return StoryRoomComAdapter
+
+# Class name has to be unique.  Our convention is camel case the
+# sitename with Adapter at the end.  www is skipped.
+class StoryRoomComAdapter(StoriesOnlineNetAdapter):
+
+    @classmethod
+    def getSiteAbbrev(cls):
+        return 'stryrm'
+
+    @staticmethod # must be @staticmethod, don't remove it.
+    def getSiteDomain():
+        # The site domain.  Does have www here, if it uses it.
+        return 'storyroom.com'

--- a/fanficfare/configurable.py
+++ b/fanficfare/configurable.py
@@ -169,6 +169,7 @@ otw_list=['archiveofourown.org',
           ]
 wpc_list=['storiesonline.net',
           'finestories.com',
+          'storyroom.com',
           'scifistories.com',
           ]
 ffnet_list=[


### PR DESCRIPTION
WPC/WLPC/SOL has replaced "finestories.com" with "storyroom.com" (created issue https://github.com/JimmXinu/FanFicFare/issues/1199)
I duplicated the 3 references I found for "finestories.com" /created new adaptor, but unsure if there was a better/preferred way to replace/alias it. Adding the "new" domain then also requires adding/updating personal.ini login section name...
Also picked a new getSiteAbbrev of "stryrm".
They seem to have removed reference to the old "finestories.com" domain (other than redirecting it to new storyroom.com, so maybe just updating legacy adapter is better?)