### PR TITLE
fix(pyproject): replace license by file to using SPDX keyword

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,10 @@ readme = "DESCRIPTION.rst" # Optional
 # https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
 requires-python = ">=3.7"
 
-# This is either text indicating the license for the distribution, or a file
-# that contains the license
+# This is SPDX keyword indicating the license for the distribution
 # https://packaging.python.org/en/latest/specifications/core-metadata/#license
-license = {file = "LICENSE"}
+# https://spdx.org/licenses/
+license = "Apache-2.0"
 
 # This field adds keywords for your project which will appear on the
 # project page. What does your project relate to?
@@ -81,9 +81,6 @@ classifiers = [  # Optional
   # Indicate who your project is intended for
   "Intended Audience :: End Users/Desktop",
   "Topic :: Internet :: WWW/HTTP",
-
-  # Pick your license as you wish
-  "License :: OSI Approved :: Apache Software License",
 
   # Specify the Python versions you support here. In particular, ensure
   # that you indicate you support Python 3. These classifiers are *not*


### PR DESCRIPTION
As per https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license