### PR TITLE
Implement Alternate Tagging and Date calculation for Literotica Series

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -2289,6 +2289,22 @@ chapter_categories_use_all: false
 ## or just use the text. If this can't be done, the full title is used.
 clean_chapter_titles: false
 
+## For stories, collect tags from individual chapter pages in addition to the
+## series page tags. This allows collection of tags beyond the top 10 on the series but 
+## if the author updates tags on a chapter and not the series, those tags may persist even if
+## the chapter is not fetched during an update.
+## Default is false to maintain previous behavior.
+tags_from_chapters: false
+
+## For multi-chapter stories (series), use the chapter approval dates for datePublished
+## and dateUpdated instead of the series metadata dates. This provides more accurate dates
+## based on actual posting dates rather than just when the series metadata changes. This
+## method can provide wildly different dates if chapters were written long before being
+## approved, if chapters are approved out of order, or if the works were approved/updated
+## before literotica's current series system was implemented.
+## Default is false to maintain previous behavior.
+dates_from_chapters: false
+
 ## Some stories mistakenly include 'Ch' or 'Pt' at the end of the
 ## story title. Appears to be a site bug or common author error.  Copy
 ## these to your personal.ini (and uncomment) to correct.

--- a/fanficfare/configurable.py
+++ b/fanficfare/configurable.py
@@ -266,6 +266,8 @@ def get_valid_set_options():
                'description_in_chapter':(['literotica.com'],None,boollist),
                'fetch_stories_from_api':(['literotica.com'],None,boollist),
                'order_chapters_by_date':(['literotica.com'],None,boollist),
+               'tags_from_chapters':(['literotica.com'],None,boollist),
+               'dates_from_chapters':(['literotica.com'],None,boollist),
 
                'inject_chapter_title':(['asianfanfics.com']+wpc_list,None,boollist),
                'inject_chapter_image':(['asianfanfics.com'],None,boollist),
@@ -520,6 +522,8 @@ def get_valid_keywords():
                  'description_in_chapter',
                  'order_chapters_by_date',
                  'fetch_stories_from_api',
+                 'tags_from_chapters',
+                 'dates_from_chapters',
                  'inject_chapter_title',
                  'inject_chapter_image',
                  'append_datepublished_to_storyurl',

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -2282,6 +2282,22 @@ chapter_categories_use_all: false
 ## or just use the text. If this can't be done, the full title is used.
 clean_chapter_titles: false
 
+## For stories, collect tags from individual chapter pages in addition to the
+## series page tags. This allows collection of tags beyond the top 10 on the series but 
+## if the author updates tags on a chapter and not the series, those tags may persist even if
+## the chapter is not fetched during an update.
+## Default is false to maintain previous behavior.
+tags_from_chapters: false
+
+## For multi-chapter stories (series), use the chapter approval dates for datePublished
+## and dateUpdated instead of the series metadata dates. This provides more accurate dates
+## based on actual posting dates rather than just when the series metadata changes. This
+## method can provide wildly different dates if chapters were written long before being
+## approved, if chapters are approved out of order, or if the works were approved/updated
+## before literotica's current series system was implemented.
+## Default is false to maintain previous behavior.
+dates_from_chapters: false
+
 ## Some stories mistakenly include 'Ch' or 'Pt' at the end of the
 ## story title. Appears to be a site bug or common author error.  Copy
 ## these to your personal.ini (and uncomment) to correct.


### PR DESCRIPTION
This is redo of [#1101](https://github.com/JimmXinu/FanFicFare/pull/1101), with the changes suggested in the comments implemented (add a config to make both changes optional). I've been using it for a bit without issues, but a code review, as always, would be welcome. 

**Alternate Tag Collection Method**
For stories, collect tags from individual chapter pages in addition to the series page tags. This allows collection of tags beyond the top 10 on the series but if the author updates tags on a chapter and not the series, those tags may persist even if the chapter is not fetched during an update. 
Default is false to maintain previous behavior.

**Alternate Date Collection Method for Series**
For multi-chapter stories (series), use the chapter approval dates for datePublished and dateUpdated instead of the series metadata dates. This provides more accurate dates based on actual posting dates rather than just when the series metadata changes. This method can provide wildly different dates if chapters were written long before being approved, if chapters are approved out of order, or if the works were approved/updated before literotica's current series system was implemented.
Default is false to maintain previous behavior.