### PR TITLE
adapter_literotica: Get series ID from data object

### DIFF
--- a/fanficfare/adapters/adapter_literotica.py
+++ b/fanficfare/adapters/adapter_literotica.py
@@ -374,7 +374,7 @@ class LiteroticaSiteAdapter(BaseSiteAdapter):
                     ## alternate chapters from JSON
                     if self.num_chapters() < 1:
                         logger.debug("Getting Chapters from series JSON")
-                        seriesid = json_state.get('series',{}).get('coversSeriesId',None)
+                        seriesid = json_state.get('series',{}).get('data',{}).get('id',None)
                         if seriesid:
                             logger.info("Fetching chapter data from JSON")
                             logger.debug(seriesid)


### PR DESCRIPTION
The following story has `coversSeriesId` set to `0`. However, `data.id` does contains the series ID, which is true for all series I looked at.

[The Most Dangerous Game](https://www.literotica.com/series/se/494186856)