### PR TITLE
fix: cover image AttributeError brought by updated "failedtoload" inspection

### DIFF
--- a/fanficfare/adapters/adapter_fimfictionnet.py
+++ b/fanficfare/adapters/adapter_fimfictionnet.py
@@ -184,7 +184,7 @@ class FimFictionNetSiteAdapter(BaseSiteAdapter):
             if storyImage:
                 coverurl = storyImage['data-fullsize']
                 # try setting from data-fullsize, if fails, try using data-src
-                if self.setCoverImage(self.url,coverurl)[0].startswith("failedtoload"):
+                if str(self.setCoverImage(self.url,coverurl)[0] or '').startswith("failedtoload"):
                     coverurl = storyImage['src']
                     self.setCoverImage(self.url,coverurl)
 

--- a/fanficfare/adapters/adapter_royalroadcom.py
+++ b/fanficfare/adapters/adapter_royalroadcom.py
@@ -289,7 +289,7 @@ class RoyalRoadAdapter(BaseSiteAdapter):
         if img:
             cover_url = img['src']
             # usually URL is for thumbnail. Try expected URL for larger image, if fails fall back to the original URL
-            if self.setCoverImage(url,cover_url.replace('/covers-full/', '/covers-large/'))[0].startswith("failedtoload"):
+            if str(self.setCoverImage(url,cover_url.replace('/covers-full/', '/covers-large/'))[0] or '').startswith("failedtoload"):
                 self.setCoverImage(url,cover_url)
                     # some content is show as tables, this will preserve them
 


### PR DESCRIPTION
`BaseSiteAdapter.setCoverImage(storyurl,imgurl)[0]` can be `None` as designed, so `BaseSiteAdapter.setCoverImage(storyurl,imgurl)[0].startswith()` would cause an AttributeError in this case.

For Example,

```pytb
Traceback (most recent call last):
  File "/usr/local/bin/fanficfare", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/fanficfare/cli.py", line 346, in main
    dispatch(options, urls, passed_defaultsini, passed_personalini, warn, fail)
  File "/usr/local/lib/python3.12/dist-packages/fanficfare/cli.py", line 322, in dispatch
    do_download(url,
  File "/usr/local/lib/python3.12/dist-packages/fanficfare/cli.py", line 437, in do_download
    adapter.getStoryMetadataOnly()
  File "/usr/local/lib/python3.12/dist-packages/fanficfare/adapters/base_adapter.py", line 376, in getStoryMetadataOnly
    self.doExtractChapterUrlsAndMetadata(get_cover=get_cover)
  File "/usr/local/lib/python3.12/dist-packages/fanficfare/adapters/base_adapter.py", line 486, in doExtractChapterUrlsAndMetadata
    return self.extractChapterUrlsAndMetadata()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/fanficfare/adapters/adapter_royalroadcom.py", line 292, in extractChapterUrlsAndMetadata
    if self.setCoverImage(url,cover_url.replace('/covers-full/', '/covers-large/'))[0].startswith("failedtoload"):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'startswith'

```