### PR TITLE
refactor: Rename `dateCreated` to `datePackaged` throughout

### DIFF
--- a/calibre-plugin/config.py
+++ b/calibre-plugin/config.py
@@ -1342,7 +1342,7 @@ permitted_values = {
     'int' : ['numWords','numChapters'],
     'float' : ['numWords','numChapters'],
     'bool' : ['status-C','status-I'],
-    'datetime' : ['datePublished', 'dateUpdated', 'dateCreated'],
+    'datetime' : ['datePublished', 'dateUpdated', 'datePackaged'],
     'series' : ['series'],
     'enumeration' : ['category',
                      'genre',
@@ -1353,7 +1353,7 @@ permitted_values = {
                      'status',
                      'datePublished',
                      'dateUpdated',
-                     'dateCreated',
+                     'datePackaged',
                      'rating',
                      'warnings',
                      'numChapters',
@@ -1390,7 +1390,7 @@ titleLabels = {
     'ships':_('Relationships'),
     'datePublished':_('Published'),
     'dateUpdated':_('Updated'),
-    'dateCreated':_('Created'),
+    'datePackaged':_('Packaged'),
     'rating':_('Rating'),
     'warnings':_('Warnings'),
     'numChapters':_('Chapters'),
@@ -1550,6 +1550,7 @@ class CustomColumnsTab(QWidget):
         horz.addWidget(label) # empty spacer for alignment with error column line.
 
         self.l.addLayout(horz)
+
 
 
 class StandardColumnsTab(QWidget):

--- a/calibre-plugin/fff_plugin.py
+++ b/calibre-plugin/fff_plugin.py
@@ -1472,8 +1472,8 @@ class FanFicFarePlugin(InterfaceAction):
                 book['pubdate'] = story.getMetadataRaw('datePublished').replace(tzinfo=local_tz)
             if story.getMetadataRaw('dateUpdated'):
                 book['updatedate'] = story.getMetadataRaw('dateUpdated').replace(tzinfo=local_tz)
-            if story.getMetadataRaw('dateCreated'):
-                book['timestamp'] = story.getMetadataRaw('dateCreated').replace(tzinfo=local_tz)
+            if story.getMetadataRaw('datePackaged'):
+                book['timestamp'] = story.getMetadataRaw('datePackaged').replace(tzinfo=local_tz)
             else:
                 book['timestamp'] = datetime.now().replace(tzinfo=local_tz) # need *something* there for calibre.
 
@@ -3071,7 +3071,7 @@ The previously downloaded book is still in the anthology, but FFF doesn't have t
                 # timestamp should be latest date.
                 if k == 'timestamp' and book[k] <= b[k]:
                     book[k]=b[k]
-                    book['all_metadata']['dateCreated'] = b['all_metadata']['dateCreated']
+                    book['all_metadata']['datePackaged'] = b['all_metadata']['datePackaged']
                 # updated should be latest date.
                 if k == 'updatedate' and book[k] <= b[k]:
                     book[k]=b[k]
@@ -3088,7 +3088,7 @@ The previously downloaded book is still in the anthology, but FFF doesn't have t
                             else:
                                 # lot of work for a simple add.
                                 book['all_metadata'][k] = unicode(int(book['all_metadata'][k].replace(',',''))+int(b['all_metadata'][k].replace(',','')))
-                    elif k in ('dateUpdated','datePublished','dateCreated',
+                    elif k in ('dateUpdated','datePublished','datePackaged',
                                'series','status','title'):
                         pass # handled above, below or skip these for now, not going to do anything with them.
                     elif k not in book['all_metadata'] or not book['all_metadata'][k]:

--- a/calibre-plugin/jobs.py
+++ b/calibre-plugin/jobs.py
@@ -214,8 +214,8 @@ def do_download_for_worker(book,options,merge,notification=lambda x,y:x):
                 book['pubdate'] = story.getMetadataRaw('datePublished').replace(tzinfo=local_tz)
             if story.getMetadataRaw('dateUpdated'):
                 book['updatedate'] = story.getMetadataRaw('dateUpdated').replace(tzinfo=local_tz)
-            if story.getMetadataRaw('dateCreated'):
-                book['timestamp'] = story.getMetadataRaw('dateCreated').replace(tzinfo=local_tz)
+            if story.getMetadataRaw('datePackaged'):
+                book['timestamp'] = story.getMetadataRaw('datePackaged').replace(tzinfo=local_tz)
             else:
                 book['timestamp'] = datetime.now().replace(tzinfo=local_tz) # need *something* there for calibre.
 

--- a/fanficfare/adapters/adapter_test1.py
+++ b/fanficfare/adapters/adapter_test1.py
@@ -164,7 +164,7 @@ Some more longer description.  "I suck at summaries!"  "Better than it sounds!" 
             self.story.setMetadata('language',langs[idnum%len(langs)])
 
         if idnum == 0:
-            self.setSeries("A Nook Hyphen Test "+self.story.getMetadata('dateCreated'),idnum)
+            self.setSeries("A Nook Hyphen Test "+self.story.getMetadata('datePackaged'),idnum)
             self.story.setMetadata('seriesUrl','http://'+self.getSiteDomain()+'/seriesid=0')
 
         self.story.setMetadata('rating','Tweenie')

--- a/fanficfare/adapters/base_adapter.py
+++ b/fanficfare/adapters/base_adapter.py
@@ -85,7 +85,7 @@ class BaseSiteAdapter(Requestable):
         self.metadataDone = False
         self.story = Story(configuration)
         self.story.setMetadata('site',self.getConfigSection())
-        self.story.setMetadata('dateCreated',datetime.now())
+        self.story.setMetadata('datePackaged',datetime.now())
         self.chapterUrls = [] # dicts of (chapter title,chapter url)
         self.chapterFirst = None
         self.chapterLast = None
@@ -396,7 +396,7 @@ try to download.</p>
                 if self.story.getMetadataRaw('datePublished'):
                     self.story.setMetadata('dateUpdated',self.story.getMetadataRaw('datePublished'))
                 else:
-                    self.story.setMetadata('dateUpdated',self.story.getMetadataRaw('dateCreated'))
+                    self.story.setMetadata('dateUpdated',self.story.getMetadataRaw('datePackaged'))
 
             self.metadataDone = True
             # normalize chapter urls.
@@ -420,7 +420,7 @@ try to download.</p>
                 if self.story.getMetadataRaw('datePublished'):
                     self.story.setMetadata('dateUpdated',self.story.getMetadataRaw('datePublished'))
                 else:
-                    self.story.setMetadata('dateUpdated',self.story.getMetadataRaw('dateCreated'))
+                    self.story.setMetadata('dateUpdated',self.story.getMetadataRaw('datePackaged'))
 
     def hookForUpdates(self,chaptercount):
         "Usually not needed."

--- a/fanficfare/adapters/base_xenforo2forum_adapter.py
+++ b/fanficfare/adapters/base_xenforo2forum_adapter.py
@@ -813,9 +813,9 @@ class BaseXenForo2ForumAdapter(BaseSiteAdapter):
                         self.threadmarks_for_reader[self.normalize_chapterurl(tm['url'])] = (tm['tmcat_num'],tm['tmcat_index'])
 
                     ## threadmark date, words available for chapter custom output
-                    ## date formate from datethreadmark_format or dateCreated_format
+                    ## date formate from datethreadmark_format or datePackaged_format
                     ## then a basic default.
-                    added = self.add_chapter(prepend+tm['title'],tm['url'],{'date':tm['date'].strftime(self.getConfig("datethreadmark_format",self.getConfig("dateCreated_format","%Y-%m-%d %H:%M:%S"))),
+                    added = self.add_chapter(prepend+tm['title'],tm['url'],{'date':tm['date'].strftime(self.getConfig("datethreadmark_format",self.getConfig("datePackaged_format","%Y-%m-%d %H:%M:%S"))),
                                                                             'words':tm['words'],
                                                                             'kwords':tm['kwords']})
                     if added and tm.get('words',None):

--- a/fanficfare/configurable.py
+++ b/fanficfare/configurable.py
@@ -55,7 +55,7 @@ from .browsercache import BrowserCache
 # [www.whofic.com]
 # titlepage_entries: category,genre, status,dateUpdated,rating
 # [epub]
-# titlepage_entries: category,genre, status,datePublished,dateUpdated,dateCreated
+# titlepage_entries: category,genre, status,datePublished,dateUpdated,datePackaged
 # [www.whofic.com:epub]
 # titlepage_entries: category,genre, status,datePublished
 # [overrides]
@@ -89,7 +89,7 @@ titleLabels = {
     'ships':'Relationships',
     'datePublished':'Published',
     'dateUpdated':'Updated',
-    'dateCreated':'Packaged',
+    'datePackaged':'Packaged',
     'rating':'Rating',
     'warnings':'Warnings',
     'numChapters':'Chapters',
@@ -366,7 +366,7 @@ def get_valid_keywords():
                  'cover_exclusion_regexp',
                  'cover_min_size',
                  'custom_columns_settings',
-                 'dateCreated_format',
+                 'datePackaged_format',
                  'datePublished_format',
                  'dateUpdated_format',
                  'datethreadmark_format',
@@ -489,7 +489,7 @@ def get_valid_scalar_entries():
                  'status',
                  'datePublished',
                  'dateUpdated',
-                 'dateCreated',
+                 'datePackaged',
                  'rating',
                  'numChapters',
                  'numWords',

--- a/fanficfare/story.py
+++ b/fanficfare/story.py
@@ -1166,7 +1166,7 @@ class Story(Requestable):
                         value = commaGroups(unicode(value))
                     except Exception as e:
                         logger.warning("Failed to add commas to %s value:(%s) exception(%s)"%(key,value,e))
-                if key in ("dateCreated"):
+                if key in ("datePackaged"):
                     value = value.strftime(self.getConfig(key+"_format","%Y-%m-%d %H:%M:%S"))
                 if key in ("datePublished","dateUpdated"):
                     value = value.strftime(self.getConfig(key+"_format","%Y-%m-%d"))

--- a/fanficfare/writers/writer_epub.py
+++ b/fanficfare/writers/writer_epub.py
@@ -262,7 +262,7 @@ div { margin: 0pt; padding: 0pt; }
                     entryre = re.escape(entryre).replace(valmarker,r'(?P<value>.+?)')
                     ## find all, use the last.
                     m = re.findall(entryre,logfile,flags=re.MULTILINE|re.DOTALL)
-                    # if entry in ("description","dateCreated") :
+                    # if entry in ("description","datePackaged") :
                     #     logger.debug("\n\n")
                     #     logger.debug(entryre)
                     #     # logger.debug(logfile)
@@ -468,10 +468,10 @@ div { margin: 0pt; padding: 0pt; }
                                             attrs={"opf:event":"publication"},
                                             text=self.story.getMetadataRaw('datePublished').strftime("%Y-%m-%d")))
 
-            if self.story.getMetadataRaw('dateCreated'):
+            if self.story.getMetadataRaw('datePackaged'):
                 metadata.appendChild(newTag(contentdom,"dc:date",
                                             attrs={"opf:event":"creation"},
-                                            text=self.story.getMetadataRaw('dateCreated').strftime("%Y-%m-%d")))
+                                            text=self.story.getMetadataRaw('datePackaged').strftime("%Y-%m-%d")))
 
             if self.story.getMetadataRaw('dateUpdated'):
                 metadata.appendChild(newTag(contentdom,"dc:date",


### PR DESCRIPTION
`dateCreated` was ambiguous — it's mapped to both `Packaged` on the title page of EPUBs as well as `Created` on the customise settings Custom Columns tab. Additionally it could imply the story's creation date on the source site, when it actually records when FanFicFare packaged the epub. Renamed instances throughout to `datePackaged` for clarity.

- fanficfare/adapters/base_adapter.py: set datePackaged on story init and use it as dateUpdated fallback
- fanficfare/configurable.py: update title page label map, format key, metadata key list, and example comment
- fanficfare/story.py: update format dispatch check
- fanficfare/writers/writer_epub.py: update epub dc:date creation block
- fanficfare/adapters/adapter_test1.py: update test series name
- fanficfare/adapters/base_xenforo2forum_adapter.py: update format config key fallback (datePackaged_format)
- calibre-plugin/jobs.py, fff_plugin.py: update book['timestamp'] population and _get_raw_custom_date_value() mapping
- calibre-plugin/config.py: update permitted_values and titleLabels (generic dropdown now shows "Packaged" instead of "Created")

Note: adapter_masseffect2in.py uses dateCreated as an HTML itemprop attribute from the source website and is intentionally left unchanged.