### PR TITLE
fix: Resort library view after book updates

### DIFF
--- a/calibre-plugin/fff_plugin.py
+++ b/calibre-plugin/fff_plugin.py
@@ -1951,6 +1951,9 @@ class FanFicFarePlugin(InterfaceAction):
         if len(update_list):
             self.gui.library_view.model().refresh_ids(update_ids)
 
+        if all_ids:
+            self.gui.library_view.model().resort()
+
         current = self.gui.library_view.currentIndex()
         self.gui.library_view.model().current_changed(current, self.previous)
         self.gui.tags_view.recount()


### PR DESCRIPTION
After a successful download or metadata update, `refresh_ids()` was called to update the display data for changed rows, but the library view was not resorted. This meant books sorted by a column that FanFicFare had just written would not reorder into their correct position until the user manually triggered a sort.

Added a `resort()` call on the library view model after `all_ids` are refreshed so the current sort order is re-applied automatically.