### PR TITLE
fix: Align custom date columns with title page metadata

### DIFF
--- a/calibre-plugin/fff_plugin.py
+++ b/calibre-plugin/fff_plugin.py
@@ -2387,6 +2387,13 @@ class FanFicFarePlugin(InterfaceAction):
         except Exception as e:
             raise_exception(meta,val,label,e)
 
+    def _get_raw_custom_date_value(self, book, meta):
+        return {
+            'datePublished': book.get('pubdate'),
+            'dateUpdated': book.get('updatedate'),
+            'dateCreated': book.get('timestamp'),
+        }.get(meta)
+
     def update_metadata(self, db, book_id, book, mi, options):
         oldmi = db.get_metadata(book_id,index_is_id=True)
         if prefs['keeptags']:
@@ -2480,7 +2487,13 @@ class FanFicFarePlugin(InterfaceAction):
                 continue
             label = coldef['label']
             if coldef['datatype'] in ('enumeration','comments','datetime','series'):
-                self.set_custom(db, book_id, meta, book['all_metadata'][meta], label, commit=False)
+                val = book['all_metadata'][meta]
+                if coldef['datatype'] == 'datetime':
+                    val = self._get_raw_custom_date_value(book, meta)
+                    if not val:
+                        logger.debug("No raw datetime value for %s, skipping custom column(%s) update."%(meta,coldef['name']))
+                        continue
+                self.set_custom(db, book_id, meta, val, label, commit=False)
             elif coldef['datatype'] == 'text':
                 joined_val = book['all_metadata'][meta]
                 # 'Contains names' custom columns need & separators.
@@ -2559,6 +2572,8 @@ class FanFicFarePlugin(InterfaceAction):
                                         val = sum(items)
                             else:
                                 val = unicode(val).replace(",","")
+                        elif coldef['datatype'] == 'datetime':
+                            val = self._get_raw_custom_date_value(book, meta)
                         else:
                             val = val
                         if coldef['datatype'] == 'bool':
@@ -2569,7 +2584,7 @@ class FanFicFarePlugin(InterfaceAction):
                             else:
                                 val = None # for tri-state 'booleans'. Yes/No/Null
                         # logger.debug("setting 'r' or 'added':meta:%s label:%s val:%s"%(meta,label,val))
-                        if val != '':
+                        if val not in ('', None):
                             self.set_custom(db, book_id, meta, val, label=label, commit=False)
 
                     if flag == 'a':


### PR DESCRIPTION
## Summary

Custom Calibre date columns mapped to `datePublished`, `dateUpdated`, or `dateCreated` were being written with formatted strings from `book['all_metadata']` instead of the raw `datetime` objects tracked on the book dict. Calibre's datetime columns require actual `datetime` objects — feeding a string silently fails or stores a null/wrong value.

- Add `_get_raw_custom_date_value()` helper to map metadata key names to the corresponding raw `datetime` from the book dict (`pubdate`, `updatedate`, `timestamp`)
- In both the main `custom_cols` write path and the `custom_cols_newonly`/append path, intercept `datetime`-type columns and use the raw value instead of the formatted string
- Skip the write (with a debug log) if the site did not provide that date, rather than writing `None`
- Guard the newonly/append path against `None` by changing `if val != ''` to `if val not in ('', None)`