### PR TITLE
refactor: Fall back to `dateCreated` for `dateUpdated`, not `datePublished`

### DIFF
--- a/fanficfare/adapters/base_adapter.py
+++ b/fanficfare/adapters/base_adapter.py
@@ -393,10 +393,7 @@ try to download.</p>
             self.story.clear_processed_metadata_cache()
 
             if not self.story.getMetadataRaw('dateUpdated'):
-                if self.story.getMetadataRaw('datePublished'):
-                    self.story.setMetadata('dateUpdated',self.story.getMetadataRaw('datePublished'))
-                else:
-                    self.story.setMetadata('dateUpdated',self.story.getMetadataRaw('dateCreated'))
+                self.story.setMetadata('dateUpdated',self.story.getMetadataRaw('dateCreated'))
 
             self.metadataDone = True
             # normalize chapter urls.
@@ -417,10 +414,7 @@ try to download.</p>
             self.story.load_html_metadata(metahtml)
             self.metadataDone = True
             if not self.story.getMetadataRaw('dateUpdated'):
-                if self.story.getMetadataRaw('datePublished'):
-                    self.story.setMetadata('dateUpdated',self.story.getMetadataRaw('datePublished'))
-                else:
-                    self.story.setMetadata('dateUpdated',self.story.getMetadataRaw('dateCreated'))
+                self.story.setMetadata('dateUpdated',self.story.getMetadataRaw('dateCreated'))
 
     def hookForUpdates(self,chaptercount):
         "Usually not needed."


### PR DESCRIPTION
When a site does not provide `dateUpdated` (when the latest chapter was uploaded), the previous fallback used `datePublished` (the date the story was first posted) before `dateCreated` (`datePackaged`). For a long-running story, `datePublished` could be years in the past and is a poor proxy for when the story was last updated.

`dateCreated` (when FanFicFare packaged the epub) is a much better fallback — for a user who regularly fetches new chapters, it much more closely approximates when new content was last available.