### PR TITLE
adapter_kakuyomujp: site update

### DIFF
--- a/fanficfare/adapters/adapter_kakuyomujp.py
+++ b/fanficfare/adapters/adapter_kakuyomujp.py
@@ -163,7 +163,7 @@ class KakuyomuJpAdapter(BaseSiteAdapter):
         titles = []
         nestingLevel = 0
         newSection = False
-        for tocNodeRef in info[workKey]['tableOfContents']:
+        for tocNodeRef in info[workKey]['tableOfContentsV2']:
             tocNode = info[tocNodeRef['__ref']]
 
             if tocNode['chapter'] is not None:


### PR DESCRIPTION
The table of contents was moved into a different key in the JSON, but seemingly nothing else changed. Tested on the example story and a few others.