### PR TITLE
Add content validation for Story With Images in FictionManiaTVAdapter

### DIFF
--- a/fanficfare/adapters/adapter_fictionmaniatv.py
+++ b/fanficfare/adapters/adapter_fictionmaniatv.py
@@ -179,7 +179,13 @@ class FictionManiaTVAdapter(BaseSiteAdapter):
                 ## if both markers are found, assume whatever is in between
                 ## is the chapter text.
                 soup = self.make_soup(data[data.index(beginmarker):data.index(endmarker)])
+
+                ## Verify that there's actual content, not just an empty document
+                if len(soup.get_text(strip=True)) < 50:
+                    raise ValueError("Story content is empty or too short")
+
                 return self.utf8FromSoup(htmlurl,soup)
+
             except Exception as e:
                 # logger.debug(e)
                 # logger.debug(soup)
@@ -209,5 +215,9 @@ class FictionManiaTVAdapter(BaseSiteAdapter):
 
             content = soup.find('body')
             content.name='div'
+
+            ## Verify that there's actual content, not just an empty document
+            if len(content.get_text(strip=True)) < 50:
+                raise ValueError("Story content is empty or too short")
 
             return self.utf8FromSoup(url,content)


### PR DESCRIPTION
Certain fictionmania.tv stories (examples below) successfully return headers/markers when using the readhtmlstory.html url pattern but the actual content is blank. I added a simple content check to validate that content exists and used a 50 character threshold to count it as actual content, not filler of some sort. 

As a safety, I added the same check for the readxstory.html pattern, so if no content exists in either, it will return an overall failure. That extra check may not be necessary, as I haven't encountered that scenario, but I figure it doesn't hurt to validate.

Example Stories
fictionmania.tv/stories/readxstory.html?storyID=322358537280557935
fictionmania.tv/stories/readxstory.html?storyID=321807563976248770
fictionmania.tv/stories/readxstory.html?storyID=3212408332186164496