### PR TITLE
Ficbook: enable replace_text_formatting for epub output

### DIFF
--- a/calibre-plugin/plugin-defaults.ini
+++ b/calibre-plugin/plugin-defaults.ini
@@ -2080,6 +2080,11 @@ dateUpdated_format:%%Y-%%m-%%d %%H:%%M
 ## your personal.ini and list the ones you don't want.
 #exclude_notes:headnotes,footnotes
 
+[ficbook.net:epub]
+## ficbook uses plain text with \n for paragraph instead of <p>
+## tags.  This replaces those \n with <br/> for epub.
+replace_text_formatting:true
+
 [ficbook.net:txt]
 ## ficbook uses CSS white-space: pre-wrap instead of tags for
 ## paragraph breaks.  This doesn't carry over to txt output.  This

--- a/fanficfare/defaults.ini
+++ b/fanficfare/defaults.ini
@@ -2073,6 +2073,11 @@ dateUpdated_format:%%Y-%%m-%%d %%H:%%M
 ## your personal.ini and list the ones you don't want.
 #exclude_notes:headnotes,footnotes
 
+[ficbook.net:epub]
+## ficbook uses plain text with \n for paragraph instead of <p>
+## tags.  This replaces those \n with <br/> for epub.
+replace_text_formatting:true
+
 [ficbook.net:txt]
 ## ficbook uses CSS white-space: pre-wrap instead of tags for
 ## paragraph breaks.  This doesn't carry over to txt output.  This


### PR DESCRIPTION
Ficbook serves chapter content as a single text node with `\n` as paragraph separators, relying on CSS `white-space: pre-wrap`. The `replace_text_formatting` option (which converts `\n` to `<br/>`) was only enabled under `[ficbook.net:txt]`, leaving epub output with raw `\n` that most epub readers collapse into a single block of text.

Added `[ficbook.net:epub]` section with `replace_text_formatting:true`.

Tested with https://ficbook.net/readfic/12947785/33254965 — paragraphs render correctly in epub output.